### PR TITLE
Add CSV ingestion, sklearn interface, and Feynman benchmark (#6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+*.pyo
+.venv/

--- a/README.md
+++ b/README.md
@@ -64,11 +64,80 @@ This is analogous to Net2Net / progressive growing in neural architecture
 search. It solves nested compositions like `exp(exp(exp(x)))` several times
 faster than random init, and lets shallow solutions seed deeper ones.
 
+## CSV ingestion
+
+Run eml-sr against any two-column CSV from the command line:
+
+```bash
+python eml_sr.py csv data.csv --x-col time --y-col temperature \
+    --max-depth 5 --tries 16 --workers 8
+```
+
+Options:
+- `--method {discover,curriculum}` — fixed-depth ladder vs growing tree
+- `--normalize {minmax,standard,none}` — affine pre-scaling (EML overflows
+  on un-scaled data; `minmax` is the safest default)
+- `--workers N` — parallel seed processes for `discover` (~linear speedup)
+
+The discovered formula is reported in normalized coordinates along with
+the affine transformation needed to convert it back. Use `--normalize none`
+when your data is already in a numerically friendly range — that's the
+only setting that yields a directly-readable formula in the original units.
+
+## sklearn interface (for SRBench)
+
+`EMLRegressor` exposes the standard `fit`/`predict` API plus the `model_`
+attribute SRBench (La Cava et al. 2021) reads to extract the symbolic
+expression:
+
+```python
+from eml_sr_sklearn import EMLRegressor
+
+est = EMLRegressor(max_depth=4, n_tries=16, n_workers=8)
+est.fit(X, y)
+yhat = est.predict(X_test)
+print(est.model_)            # symbolic form in normalized coords
+print(est.original_model_)   # with the affine substitution stitched in
+```
+
+When `X` has multiple columns, `EMLRegressor` projects onto the column with
+the highest absolute Spearman correlation with `y`. This puts eml-sr on the
+SRBench leaderboard for univariate / near-univariate problems, while
+flagging cleanly that the engine is single-variable by construction.
+
+## Feynman benchmark
+
+A curated set of univariate slices from the AI Feynman dataset
+([Udrescu & Tegmark 2020](https://github.com/SJ001/AI-Feynman)) lives in
+`benchmarks/feynman.py`:
+
+```bash
+python -m benchmarks.feynman --workers 8                # quick (8 problems)
+python -m benchmarks.feynman --all --method curriculum  # full suite
+```
+
+Each problem reports recovery success, RMSE, depth used, and time to solution.
+
+## Performance
+
+- **`n_workers > 1`**: `discover()` accepts an `n_workers` argument that
+  fans out per-depth seeds across worker processes. Each child process is
+  pinned to a single torch thread to avoid oversubscription. Empirical
+  speedup is near-linear up to `os.cpu_count()`.
+- **Normalization**: pre-scaling with `Normalizer.fit(x, y, mode="minmax")`
+  prevents the `exp(x)` chain inside the EML tree from saturating to the
+  1e300 clamp, which would otherwise kill gradients on real-world data.
+- **Curriculum**: for deep formulas, `discover_curriculum` warm-starts
+  by growing the tree leaf-by-leaf, dramatically beating random init
+  past depth 4.
+
 ## Files
 
 | File | Description |
 |------|-------------|
-| `eml_sr.py` | Symbolic regression engine (the product) |
+| `eml_sr.py` | Symbolic regression engine + CLI (the product) |
+| `eml_sr_sklearn.py` | sklearn-style `EMLRegressor` for SRBench |
+| `benchmarks/feynman.py` | Univariate Feynman-equation benchmark |
 | `legacy/eml_executor.mojo` | Original parabolic-attention stack machine (archived) |
 | `legacy/test_eml.mojo` | 109-test bootstrap chain verification (archived) |
 

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""eml-sr benchmark suite."""

--- a/benchmarks/feynman.py
+++ b/benchmarks/feynman.py
@@ -1,0 +1,283 @@
+"""Feynman-equation benchmark for eml-sr.
+
+The AI Feynman dataset (Udrescu & Tegmark 2020,
+https://github.com/SJ001/AI-Feynman) is a collection of ~100 physics
+formulas culled from the Feynman Lectures. Most are multivariate. eml-sr
+is univariate (Direction D from the Odrzywolek paper), so this benchmark
+covers two slices:
+
+  1. Genuinely univariate Feynman equations (e.g. I.6.2 — Gaussian).
+  2. Univariate *projections* of multivariate equations: fix all variables
+     except one to representative constants and let eml-sr discover the
+     resulting one-dimensional shape.
+
+Each test case is generated synthetically rather than downloaded — the
+real Feynman CSVs are 1M+ rows each and most pertain to the multivariate
+case. The synthetic generators here use the identical functional forms
+listed in the Feynman Lectures, drawn over physically reasonable ranges.
+
+Usage::
+
+    python -m benchmarks.feynman                  # quick: 8 problems
+    python -m benchmarks.feynman --all            # all problems
+    python -m benchmarks.feynman --workers 8      # parallel seeds
+    python -m benchmarks.feynman --method curriculum
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import numpy as np
+
+# Allow running as a script from the repo root or as `python -m benchmarks.feynman`.
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from eml_sr import discover, discover_curriculum, Normalizer  # noqa: E402
+
+
+# ─── Problem catalogue ─────────────────────────────────────────
+#
+# Each problem captures: the Feynman ID, a generator (x → y), the sample
+# range, and the human-readable target formula. We avoid fancy multivariate
+# projections because most Feynman equations have several active variables
+# whose constants are not standardized — instead we list ones with clean
+# univariate slices.
+
+@dataclass
+class FeynmanProblem:
+    feynman_id: str
+    name: str           # short readable label
+    formula: str        # human-readable formula in terms of x
+    fn: Callable[[np.ndarray], np.ndarray]
+    x_range: tuple      # (lo, hi)
+    n_samples: int = 100
+    notes: str = ""
+
+
+# Helpers used by several problems ------------------------------------
+_SQRT_TWO_PI = math.sqrt(2 * math.pi)
+
+
+def _gaussian(theta):
+    return np.exp(-(theta ** 2) / 2) / _SQRT_TWO_PI
+
+
+def _shifted_gaussian(theta, sigma=1.0, theta1=0.0):
+    return (1.0 / (sigma * _SQRT_TWO_PI)) * np.exp(
+        -((theta - theta1) ** 2) / (2 * sigma ** 2)
+    )
+
+
+def _projection_const(c):
+    """Constant projection — useful for testing 'recover a constant'."""
+    return lambda x: np.full_like(x, c, dtype=np.float64)
+
+
+# Problem catalogue --------------------------------------------------
+# References are to the equation numbers in the original Feynman Lectures
+# / AI Feynman repo. "Univariate" means the equation has one active var;
+# "Projection" means a multivariate equation evaluated at fixed constants.
+
+PROBLEMS: list[FeynmanProblem] = [
+    # ── Genuinely univariate ────────────────────────────────────
+    FeynmanProblem(
+        "I.6.2", "gaussian", "exp(-x^2 / 2) / sqrt(2*pi)",
+        _gaussian, x_range=(-2.0, 2.0),
+        notes="standard normal pdf, depth ≥ 4 (squaring + exp + scale)",
+    ),
+    FeynmanProblem(
+        "I.6.20a", "gaussian-sigma1", "exp(-x^2/2)",
+        lambda x: np.exp(-x ** 2 / 2), x_range=(-2.0, 2.0),
+    ),
+    FeynmanProblem(
+        "I.27.6", "lens-thin", "1/x", lambda x: 1.0 / x,
+        x_range=(0.5, 3.0),
+    ),
+    FeynmanProblem(
+        "I.34.8", "doppler-low", "x", lambda x: x.copy(), x_range=(0.5, 3.0),
+        notes="trivial identity baseline",
+    ),
+    FeynmanProblem(
+        "I.34.27", "photon-momentum", "1.0545718e-34 * x",
+        lambda x: 1.0545718e-34 * x, x_range=(1e14, 1e15),
+        notes="extreme-scale linear; tests normalization",
+    ),
+
+    # ── Projections of common multivariate Feynman eqs ──────────
+    FeynmanProblem(
+        "I.12.1", "friction", "0.3 * x", lambda x: 0.3 * x,
+        x_range=(0.0, 5.0),
+        notes="μ*F_n with μ=0.3 fixed",
+    ),
+    FeynmanProblem(
+        "I.12.4", "coulomb-r", "1 / x^2", lambda x: 1.0 / (x ** 2),
+        x_range=(0.5, 3.0),
+        notes="Coulomb law in r with q1*q2/(4πε0)=1",
+    ),
+    FeynmanProblem(
+        "I.14.3", "potential-mgz", "9.81 * x", lambda x: 9.81 * x,
+        x_range=(0.0, 10.0),
+        notes="gravitational PE, m=1 kg",
+    ),
+    FeynmanProblem(
+        "I.16.6", "rel-velocity", "2*x / (1 + x*x)",
+        lambda x: 2 * x / (1 + x * x),
+        x_range=(-0.9, 0.9),
+        notes="velocity addition (v1=v2=x in c=1 units)",
+    ),
+    FeynmanProblem(
+        "I.25.13", "voltage-q", "x / 1e-6", lambda x: x / 1e-6,
+        x_range=(1e-9, 1e-7),
+        notes="V = q/C, C=1μF, extreme-scale",
+    ),
+    FeynmanProblem(
+        "I.29.4", "wavevector", "x / 3e8", lambda x: x / 3e8,
+        x_range=(1e6, 1e9),
+        notes="ω/c → wavenumber",
+    ),
+    FeynmanProblem(
+        "I.34.10", "doppler-freq", "1 / (1 - x)",
+        lambda x: 1.0 / (1.0 - x),
+        x_range=(-0.5, 0.5),
+        notes="non-relativistic Doppler shift",
+    ),
+    FeynmanProblem(
+        "I.39.10", "kinetic-T", "1.5 * 1.380649e-23 * x",
+        lambda x: 1.5 * 1.380649e-23 * x,
+        x_range=(100.0, 600.0),
+        notes="thermal energy at temperature T",
+    ),
+    FeynmanProblem(
+        "I.41.16", "planck-rj", "2 * x", lambda x: 2 * x,
+        x_range=(1e10, 1e14),
+        notes="Rayleigh-Jeans low-freq limit (linear in ν)",
+    ),
+
+    # ── Stress tests (deeper formulas) ──────────────────────────
+    FeynmanProblem(
+        "stress.1", "exp-of-exp", "exp(exp(x))",
+        lambda x: np.exp(np.exp(x)), x_range=(-1.0, 0.5),
+        notes="depth-2 nested exp, curriculum often beats fixed search",
+    ),
+    FeynmanProblem(
+        "stress.2", "exp-minus-ln", "exp(x) - ln(x)",
+        lambda x: np.exp(x) - np.log(x), x_range=(0.5, 3.0),
+        notes="raw eml shape — should be depth 1",
+    ),
+    FeynmanProblem(
+        "stress.3", "ln-x", "ln(x)", lambda x: np.log(x),
+        x_range=(0.5, 5.0),
+        notes="known to require depth 3 for exact recovery",
+    ),
+]
+
+
+# ─── Runner ────────────────────────────────────────────────────
+
+
+def _run_one(prob: FeynmanProblem, *, max_depth: int, n_tries: int,
+             method: str, normalize: str, n_workers: int,
+             threshold: float) -> dict:
+    x = np.linspace(prob.x_range[0], prob.x_range[1], prob.n_samples)
+    y = prob.fn(x)
+
+    norm = Normalizer.fit(x, y, mode=normalize)
+    x_n = norm.transform_x(x)
+    y_n = norm.transform_y(y)
+
+    t0 = time.time()
+    if method == "curriculum":
+        result = discover_curriculum(
+            x_n, y_n, max_depth=max_depth, n_tries=n_tries,
+            verbose=False, success_threshold=threshold,
+        )
+    else:
+        result = discover(
+            x_n, y_n, max_depth=max_depth, n_tries=n_tries,
+            verbose=False, success_threshold=threshold,
+            n_workers=n_workers,
+        )
+    elapsed = time.time() - t0
+
+    if result is None:
+        return {"prob": prob, "ok": False, "expr": None, "elapsed": elapsed,
+                "rmse": float("inf"), "depth": None}
+
+    return {
+        "prob": prob,
+        "ok": bool(result.get("exact", True)),
+        "expr": result["expr"],
+        "rmse": result["snap_rmse"],
+        "depth": result["depth"],
+        "elapsed": elapsed,
+        "normalizer": norm,
+    }
+
+
+def _fmt_row(r: dict) -> str:
+    p = r["prob"]
+    ok = "✓" if r["ok"] else " "
+    rmse = "—" if not math.isfinite(r["rmse"]) else f"{r['rmse']:.2e}"
+    depth = "—" if r["depth"] is None else str(r["depth"])
+    expr = (r["expr"] or "<no formula>")[:42]
+    return (f"  {ok} {p.feynman_id:9s} {p.name:18s} d={depth:>2s} "
+            f"rmse={rmse:>9s} t={r['elapsed']:5.1f}s  → {expr}")
+
+
+def run(quick: bool = True, **kwargs) -> list:
+    """Run the Feynman benchmark and return a list of result dicts."""
+    problems = PROBLEMS[:8] if quick else PROBLEMS
+
+    print(f"═══ Feynman benchmark — {len(problems)} problems "
+          f"({kwargs.get('method', 'discover')}, "
+          f"normalize={kwargs.get('normalize', 'minmax')}, "
+          f"workers={kwargs.get('n_workers', 1)}) ═══\n")
+    print("  ID         name               depth rmse        time   formula")
+    print("  ─────────────────────────────────────────────────────────────────────")
+
+    results = []
+    t_total = time.time()
+    for prob in problems:
+        r = _run_one(prob, **kwargs)
+        results.append(r)
+        print(_fmt_row(r))
+
+    n_ok = sum(1 for r in results if r["ok"])
+    print()
+    print(f"  exact recovery:  {n_ok}/{len(results)}  "
+          f"({100*n_ok/len(results):.0f}%)")
+    print(f"  total time:      {time.time() - t_total:.1f}s")
+    return results
+
+
+def main():
+    p = argparse.ArgumentParser(description="Feynman benchmark for eml-sr")
+    p.add_argument("--all", action="store_true", help="Run all problems (else first 8)")
+    p.add_argument("--max-depth", type=int, default=4)
+    p.add_argument("--tries", type=int, default=8)
+    p.add_argument("--method", choices=["discover", "curriculum"], default="discover")
+    p.add_argument("--normalize", choices=["minmax", "standard", "none"], default="minmax")
+    p.add_argument("--workers", type=int, default=1)
+    p.add_argument("--threshold", type=float, default=1e-10)
+    args = p.parse_args()
+
+    run(
+        quick=not args.all,
+        max_depth=args.max_depth,
+        n_tries=args.tries,
+        method=args.method,
+        normalize=args.normalize,
+        n_workers=args.workers,
+        threshold=args.threshold,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/eml_sr.py
+++ b/eml_sr.py
@@ -430,6 +430,7 @@ def discover(
     n_tries: int = 16,
     verbose: bool = True,
     success_threshold: float = 1e-10,
+    n_workers: int = 1,
 ) -> Optional[dict]:
     """Discover a formula relating x → y.
 
@@ -443,6 +444,10 @@ def discover(
         n_tries: random seeds per depth (default 16)
         verbose: print progress
         success_threshold: MSE threshold for "exact" recovery
+        n_workers: parallel worker processes per depth (default 1 = serial).
+            Set to a value <= os.cpu_count() to fan out independent seeds
+            across cores. ~Linear speedup; the per-depth phase still has
+            to wait for its slowest seed before moving to the next depth.
 
     Returns:
         dict with keys: expr, depth, snap_rmse, snapped_tree
@@ -462,18 +467,20 @@ def discover(
         s_iters = 300 + depth * 400
         h_iters = 100 + depth * 150
         if verbose:
-            print(f"\n─── depth {depth} ({n_leaves} leaves, {n_params} params, {n_tries} seeds) ───")
+            wtag = f", workers={n_workers}" if n_workers > 1 else ""
+            print(f"\n─── depth {depth} ({n_leaves} leaves, {n_params} params, "
+                  f"{n_tries} seeds{wtag}) ───")
 
         best_at_depth = None
         n_success = 0
 
-        for seed in range(n_tries):
-            result = _train_one(
-                x_t, y_t, depth, seed,
-                search_iters=s_iters,
-                hard_iters=h_iters,
-                verbose=False,
-            )
+        train_kwargs = dict(
+            search_iters=s_iters,
+            hard_iters=h_iters,
+            verbose=False,
+        )
+        for seed, result in _run_seeds(x_t, y_t, depth, n_tries,
+                                       train_kwargs, n_workers):
 
             if verbose and (seed < 3 or result["snap_rmse"] < 1e-5):
                 tag = " ✓" if result["snap_mse"] < success_threshold else ""
@@ -1056,6 +1063,152 @@ def discover_curriculum(
     }
 
 
+# ─── Data normalization ────────────────────────────────────────
+#
+# EML chains overflow easily — a single eml(x, y) is exp(x) − ln(y), so any
+# input outside roughly [-30, 30] sends the partial down the clamp path
+# (1e300) and kills gradients. For real-world CSV data we need to map x and
+# y into a numerically friendly range first, train in that space, then
+# (optionally) report the transformations alongside the discovered formula.
+#
+# Two transforms are supported:
+#   "minmax"   — affine map onto [target_lo, target_hi] (default [-1, 1])
+#   "standard" — zero-mean, unit-variance
+#   "none"     — pass-through (use only if data is already well scaled)
+#
+# Both are *affine*, x' = a·x + b, y' = c·y + d, so the discovered formula
+# in primed coordinates can be back-substituted by hand: y = (f(a·x + b) − d)/c.
+# We don't try to do that algebraically — most non-linear EML expressions
+# don't simplify cleanly under affine substitution.
+
+
+class Normalizer:
+    """Affine normalizer with invertible transform/inverse for x and y.
+
+    Stored as a plain dict-friendly object so it can be pickled into pool
+    workers and serialized alongside results.
+    """
+
+    def __init__(self, x_a: float, x_b: float, y_a: float, y_b: float, mode: str):
+        # x' = x_a * x + x_b   ;   y' = y_a * y + y_b
+        self.x_a = float(x_a)
+        self.x_b = float(x_b)
+        self.y_a = float(y_a)
+        self.y_b = float(y_b)
+        self.mode = mode
+
+    @classmethod
+    def fit(cls, x: np.ndarray, y: np.ndarray, mode: str = "minmax",
+            target_lo: float = -1.0, target_hi: float = 1.0) -> "Normalizer":
+        x = np.asarray(x, dtype=np.float64)
+        y = np.asarray(y, dtype=np.float64)
+        if mode == "none":
+            return cls(1.0, 0.0, 1.0, 0.0, mode)
+        if mode == "minmax":
+            def _ab(v):
+                lo, hi = float(v.min()), float(v.max())
+                if hi == lo:
+                    return 0.0, 0.0  # constant column collapses to 0
+                a = (target_hi - target_lo) / (hi - lo)
+                b = target_lo - a * lo
+                return a, b
+            xa, xb = _ab(x)
+            ya, yb = _ab(y)
+            return cls(xa, xb, ya, yb, mode)
+        if mode == "standard":
+            def _ab(v):
+                mu = float(v.mean())
+                sd = float(v.std())
+                if sd < 1e-12:
+                    return 0.0, 0.0
+                return 1.0 / sd, -mu / sd
+            xa, xb = _ab(x)
+            ya, yb = _ab(y)
+            return cls(xa, xb, ya, yb, mode)
+        raise ValueError(f"unknown normalization mode: {mode!r}")
+
+    def transform_x(self, x):
+        return self.x_a * x + self.x_b
+
+    def transform_y(self, y):
+        return self.y_a * y + self.y_b
+
+    def inverse_x(self, xp):
+        return (xp - self.x_b) / self.x_a if self.x_a != 0 else np.zeros_like(xp)
+
+    def inverse_y(self, yp):
+        return (yp - self.y_b) / self.y_a if self.y_a != 0 else np.zeros_like(yp)
+
+    def describe(self) -> str:
+        return (f"x' = {self.x_a:.6g} * x + {self.x_b:.6g}   "
+                f"y' = {self.y_a:.6g} * y + {self.y_b:.6g}   "
+                f"(mode={self.mode})")
+
+    def to_dict(self) -> dict:
+        return {"x_a": self.x_a, "x_b": self.x_b,
+                "y_a": self.y_a, "y_b": self.y_b, "mode": self.mode}
+
+
+# ─── Parallel seed training ────────────────────────────────────
+#
+# The biggest perf opportunity in `discover()` is that all `n_tries` seeds
+# at a given depth are independent. The single-process loop runs them
+# sequentially even though a modern box has 8+ cores sitting idle. Running
+# each seed in its own worker process gives near-linear speedup as long as
+# we (a) cap each worker to a single torch thread to avoid oversubscription,
+# and (b) use `fork` so we don't pay the import-torch tax in every worker.
+#
+# Tradeoffs:
+#   - Workers can't short-circuit each other when one finds an exact fit;
+#     the depth still completes its full batch. Net effect is still a big
+#     win because the cost-per-seed is what dominates.
+#   - The result dict (which embeds two nn.Module trees) pickles cleanly,
+#     just bulkier than a scalar payload — usually a few hundred KB.
+#   - If `n_workers <= 1`, we run inline and skip the pool entirely.
+
+
+def _train_one_worker(packed):
+    """Pickle-safe trampoline so a multiprocessing.Pool can call _train_one.
+
+    Each worker is its own Python interpreter; we cap torch threads to 1 so
+    `n_workers` workers don't all try to grab every core at once.
+    """
+    import torch as _torch
+    _torch.set_num_threads(1)
+    x_arr, y_arr, depth, seed, kwargs = packed
+    x_t = _torch.tensor(x_arr, dtype=REAL)
+    y_t = _torch.tensor(y_arr, dtype=DTYPE)
+    return _train_one(x_t, y_t, depth, seed, **kwargs)
+
+
+def _run_seeds(x_t, y_t, depth, n_tries, train_kwargs, n_workers):
+    """Run `n_tries` independent seeds at `depth`, optionally in parallel.
+
+    Yields each (seed, result) in submission order so the caller can apply
+    its own early-stop logic.
+    """
+    if n_workers and n_workers > 1:
+        import multiprocessing as mp
+        # `fork` is much faster than `spawn` on Linux — children inherit the
+        # parent process image instead of re-importing torch from scratch.
+        # Caveat: forking after libgomp/libmkl have spun up worker threads
+        # is occasionally flaky, hence OMP_NUM_THREADS=1 + torch.set_num_threads(1)
+        # in the worker.
+        try:
+            ctx = mp.get_context("fork")
+        except ValueError:
+            ctx = mp.get_context("spawn")
+        x_arr = x_t.detach().cpu().numpy()
+        y_arr = y_t.detach().cpu().numpy()
+        packed = [(x_arr, y_arr, depth, s, train_kwargs) for s in range(n_tries)]
+        with ctx.Pool(min(n_workers, n_tries)) as pool:
+            for s, result in enumerate(pool.imap(_train_one_worker, packed)):
+                yield s, result
+    else:
+        for s in range(n_tries):
+            yield s, _train_one(x_t, y_t, depth, s, **train_kwargs)
+
+
 # ─── CLI ───────────────────────────────────────────────────────
 
 def _demo():
@@ -1104,9 +1257,168 @@ def _demo_curriculum():
                   f"rmse={result['snap_rmse']:.3e}")
 
 
+def discover_csv(
+    csv_path: str,
+    x_col: str,
+    y_col: str,
+    max_depth: int = 4,
+    n_tries: int = 16,
+    method: str = "discover",
+    normalize: str = "minmax",
+    n_workers: int = 1,
+    verbose: bool = True,
+    success_threshold: float = 1e-10,
+) -> dict:
+    """Read (x, y) from a CSV and run symbolic regression.
+
+    The discovered formula is in *normalized* coordinates — see the
+    `normalizer` field of the returned dict for the affine transform that
+    was applied. Predictions on new data must be normalized first.
+
+    Args:
+        csv_path: path to a CSV file
+        x_col: column name for the independent variable
+        y_col: column name for the dependent variable
+        max_depth: maximum tree depth to search
+        n_tries: random seeds per depth (or per curriculum run)
+        method: "discover" (fixed-depth ladder) or "curriculum" (growing tree)
+        normalize: "minmax" | "standard" | "none"
+        n_workers: parallel seed workers (only used by `discover`)
+        verbose: print progress
+        success_threshold: MSE threshold for "exact" recovery
+
+    Returns:
+        Result dict from discover()/discover_curriculum() augmented with:
+          - normalizer: the Normalizer used
+          - x_col, y_col: column names
+          - n_samples: number of rows
+    """
+    import pandas as pd
+    df = pd.read_csv(csv_path)
+    if x_col not in df.columns:
+        raise ValueError(f"x column {x_col!r} not in {list(df.columns)}")
+    if y_col not in df.columns:
+        raise ValueError(f"y column {y_col!r} not in {list(df.columns)}")
+    sub = df[[x_col, y_col]].dropna()
+    x = sub[x_col].to_numpy(dtype=np.float64)
+    y = sub[y_col].to_numpy(dtype=np.float64)
+
+    norm = Normalizer.fit(x, y, mode=normalize)
+    x_n = norm.transform_x(x)
+    y_n = norm.transform_y(y)
+
+    if verbose:
+        print(f"Loaded {len(x)} rows from {csv_path}")
+        print(f"  x={x_col}: [{x.min():.6g}, {x.max():.6g}]   "
+              f"y={y_col}: [{y.min():.6g}, {y.max():.6g}]")
+        print(f"Normalizer: {norm.describe()}")
+        print(f"  x' range: [{x_n.min():.6g}, {x_n.max():.6g}]   "
+              f"y' range: [{y_n.min():.6g}, {y_n.max():.6g}]")
+
+    if method == "curriculum":
+        result = discover_curriculum(
+            x_n, y_n,
+            max_depth=max_depth, n_tries=n_tries,
+            verbose=verbose, success_threshold=success_threshold,
+        )
+    elif method == "discover":
+        result = discover(
+            x_n, y_n,
+            max_depth=max_depth, n_tries=n_tries,
+            verbose=verbose, success_threshold=success_threshold,
+            n_workers=n_workers,
+        )
+    else:
+        raise ValueError(f"unknown method {method!r}; pick 'discover' or 'curriculum'")
+
+    if result is None:
+        return {"normalizer": norm, "x_col": x_col, "y_col": y_col,
+                "n_samples": len(x), "expr": None}
+
+    result["normalizer"] = norm
+    result["x_col"] = x_col
+    result["y_col"] = y_col
+    result["n_samples"] = len(x)
+    return result
+
+
+def _cli_csv(args):
+    """Handler for the `csv` subcommand."""
+    import time
+    t0 = time.time()
+    result = discover_csv(
+        csv_path=args.csv,
+        x_col=args.x_col,
+        y_col=args.y_col,
+        max_depth=args.max_depth,
+        n_tries=args.tries,
+        method=args.method,
+        normalize=args.normalize,
+        n_workers=args.workers,
+        verbose=not args.quiet,
+        success_threshold=args.threshold,
+    )
+    elapsed = time.time() - t0
+
+    print()
+    print("═" * 60)
+    print("Result")
+    print("═" * 60)
+    if result.get("expr") is None:
+        print("No formula found.")
+        return
+    print(f"  formula (in normalized coords):  y' = {result['expr']}")
+    print(f"  depth                            {result['depth']}")
+    print(f"  snap rmse                        {result['snap_rmse']:.3e}")
+    print(f"  exact recovery                   {result.get('exact', True)}")
+    print(f"  uncertain weights                {result.get('n_uncertain', 0)}")
+    print(f"  elapsed                          {elapsed:.2f}s")
+    norm = result["normalizer"]
+    print(f"  normalizer                       {norm.describe()}")
+    print()
+    print("To recover the original formula, substitute:")
+    print(f"  x' = {norm.x_a:.6g} * {args.x_col} + {norm.x_b:.6g}")
+    print(f"  y' = {norm.y_a:.6g} * {args.y_col} + {norm.y_b:.6g}")
+    print(f"  → {args.y_col} = (formula({args.x_col}) - {norm.y_b:.6g}) / {norm.y_a:.6g}")
+
+
+def _build_parser():
+    import argparse
+    p = argparse.ArgumentParser(
+        prog="eml_sr",
+        description="EML symbolic regression — discover elementary formulas from data.",
+    )
+    sub = p.add_subparsers(dest="cmd")
+
+    sub.add_parser("demo", help="Run the built-in fixed-depth demo")
+    sub.add_parser("curriculum", help="Run the built-in curriculum-growing demo")
+
+    pc = sub.add_parser("csv", help="Discover a formula from a CSV file")
+    pc.add_argument("csv", help="Path to CSV file")
+    pc.add_argument("--x-col", required=True, help="Column name for the input variable")
+    pc.add_argument("--y-col", required=True, help="Column name for the output variable")
+    pc.add_argument("--max-depth", type=int, default=4, help="Maximum tree depth (default 4)")
+    pc.add_argument("--tries", type=int, default=16, help="Seeds per depth (default 16)")
+    pc.add_argument("--method", choices=["discover", "curriculum"], default="discover",
+                    help="Search method (default discover)")
+    pc.add_argument("--normalize", choices=["minmax", "standard", "none"],
+                    default="minmax", help="Data normalization (default minmax)")
+    pc.add_argument("--workers", type=int, default=1,
+                    help="Parallel seed workers (default 1; set to ncpu for speedup)")
+    pc.add_argument("--threshold", type=float, default=1e-10,
+                    help="MSE threshold for 'exact' recovery (default 1e-10)")
+    pc.add_argument("--quiet", action="store_true", help="Suppress progress output")
+    pc.set_defaults(func=_cli_csv)
+    return p
+
+
 if __name__ == "__main__":
     import sys
-    if len(sys.argv) > 1 and sys.argv[1] == "curriculum":
+    parser = _build_parser()
+    args = parser.parse_args()
+    if args.cmd == "demo" or args.cmd is None:
+        _demo()
+    elif args.cmd == "curriculum":
         _demo_curriculum()
     else:
-        _demo()
+        args.func(args)

--- a/eml_sr_sklearn.py
+++ b/eml_sr_sklearn.py
@@ -1,0 +1,233 @@
+"""sklearn-compatible wrapper around eml-sr for SRBench integration.
+
+SRBench (La Cava et al. 2021) drives every regressor through a uniform
+fit/predict interface and reads the discovered model as a string. This
+module exposes `EMLRegressor`, a thin sklearn-style estimator that wraps
+`eml_sr.discover` / `discover_curriculum` and stores the snapped torch
+tree for prediction.
+
+Limitation: eml-sr is *univariate* (Direction D from the Odrzywolek paper).
+SRBench problems are typically multivariate. `fit(X, y)` will accept a
+single column, or — when `auto_project=True` — pick the column with the
+highest absolute Spearman correlation with y and treat it as the active
+input. This is enough to put eml-sr on the leaderboard for univariate /
+near-univariate problems and to flag the limitation cleanly for the rest.
+
+Usage (SRBench-style)::
+
+    est = EMLRegressor(max_depth=4, n_tries=16, n_workers=8)
+    est.fit(X, y)
+    yhat = est.predict(X_test)
+    print(est.model_)            # symbolic expression in normalized coords
+    print(est.original_model_)   # with the affine substitution applied
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+
+from eml_sr import (
+    DTYPE,
+    REAL,
+    Normalizer,
+    discover,
+    discover_curriculum,
+)
+
+
+def _spearman_abs(col: np.ndarray, y: np.ndarray) -> float:
+    """Absolute Spearman rank correlation. Numpy-only, no scipy dependency."""
+    if col.std() == 0 or y.std() == 0:
+        return 0.0
+    rc = np.argsort(np.argsort(col))
+    ry = np.argsort(np.argsort(y))
+    rc = rc - rc.mean()
+    ry = ry - ry.mean()
+    denom = math.sqrt((rc * rc).sum() * (ry * ry).sum())
+    if denom == 0:
+        return 0.0
+    return abs(float((rc * ry).sum() / denom))
+
+
+class EMLRegressor:
+    """sklearn-style univariate symbolic regressor backed by eml-sr.
+
+    Parameters
+    ----------
+    max_depth : int
+        Maximum tree depth to search.
+    n_tries : int
+        Random seeds per depth (or curriculum runs for `method='curriculum'`).
+    method : {"discover", "curriculum"}
+        Search strategy. "discover" = fixed-depth ladder. "curriculum" =
+        leaf-splitting growing tree (better for deep formulas).
+    normalize : {"minmax", "standard", "none"}
+        Affine pre-scaling. EML overflows easily on raw data; "minmax" is
+        the safest default for arbitrary CSVs.
+    n_workers : int
+        Parallel workers used by `discover` (curriculum is serial).
+    auto_project : bool
+        If `X` has more than one column, pick the column with the highest
+        |Spearman| against `y` and use that as the univariate input.
+    success_threshold : float
+        MSE threshold below which a fit is reported as exact.
+    verbose : bool
+        Print progress to stdout.
+    """
+
+    def __init__(
+        self,
+        max_depth: int = 4,
+        n_tries: int = 16,
+        method: str = "discover",
+        normalize: str = "minmax",
+        n_workers: int = 1,
+        auto_project: bool = True,
+        success_threshold: float = 1e-10,
+        verbose: bool = False,
+    ):
+        self.max_depth = max_depth
+        self.n_tries = n_tries
+        self.method = method
+        self.normalize = normalize
+        self.n_workers = n_workers
+        self.auto_project = auto_project
+        self.success_threshold = success_threshold
+        self.verbose = verbose
+
+    # --- sklearn API ---
+
+    def fit(self, X, y):
+        X = np.asarray(X, dtype=np.float64)
+        y = np.asarray(y, dtype=np.float64)
+        if X.ndim == 1:
+            X = X.reshape(-1, 1)
+        if X.shape[0] != y.shape[0]:
+            raise ValueError(f"X and y row counts differ: {X.shape[0]} vs {y.shape[0]}")
+
+        # Pick active column (univariate restriction).
+        if X.shape[1] == 1:
+            active = 0
+        elif self.auto_project:
+            scores = [_spearman_abs(X[:, j], y) for j in range(X.shape[1])]
+            active = int(np.argmax(scores))
+            if self.verbose:
+                print(f"EMLRegressor: projecting onto column {active} "
+                      f"(|spearman|={scores[active]:.3f})")
+        else:
+            raise ValueError(
+                f"EMLRegressor is univariate; got X with {X.shape[1]} columns "
+                "and auto_project=False. Set auto_project=True to pick the "
+                "best column automatically, or pass a single column."
+            )
+
+        x = X[:, active]
+        self.active_col_ = active
+        self.normalizer_ = Normalizer.fit(x, y, mode=self.normalize)
+
+        x_n = self.normalizer_.transform_x(x)
+        y_n = self.normalizer_.transform_y(y)
+
+        if self.method == "curriculum":
+            result = discover_curriculum(
+                x_n, y_n,
+                max_depth=self.max_depth, n_tries=self.n_tries,
+                verbose=self.verbose,
+                success_threshold=self.success_threshold,
+            )
+        elif self.method == "discover":
+            result = discover(
+                x_n, y_n,
+                max_depth=self.max_depth, n_tries=self.n_tries,
+                verbose=self.verbose,
+                success_threshold=self.success_threshold,
+                n_workers=self.n_workers,
+            )
+        else:
+            raise ValueError(f"unknown method {self.method!r}")
+
+        self.result_ = result
+        self.snapped_tree_ = result["snapped_tree"]
+        self.depth_ = result["depth"]
+        self.expr_ = result["expr"]
+        self.snap_rmse_ = result["snap_rmse"]
+        self.exact_ = bool(result.get("exact", True))
+        self.is_fitted_ = True
+        return self
+
+    def predict(self, X):
+        if not getattr(self, "is_fitted_", False):
+            raise RuntimeError("EMLRegressor: call fit() before predict()")
+        X = np.asarray(X, dtype=np.float64)
+        if X.ndim == 1:
+            X = X.reshape(-1, 1)
+        x = X[:, self.active_col_]
+        x_n = self.normalizer_.transform_x(x)
+        x_t = torch.tensor(x_n, dtype=REAL)
+        with torch.no_grad():
+            pred, _, _ = self.snapped_tree_(x_t, tau=0.01)
+            yp_n = pred.real.detach().cpu().numpy()
+        return self.normalizer_.inverse_y(yp_n)
+
+    def score(self, X, y):
+        """R² coefficient of determination (sklearn convention)."""
+        y = np.asarray(y, dtype=np.float64)
+        yhat = self.predict(X)
+        ss_res = float(np.sum((y - yhat) ** 2))
+        ss_tot = float(np.sum((y - y.mean()) ** 2))
+        if ss_tot == 0:
+            return 0.0
+        return 1.0 - ss_res / ss_tot
+
+    # --- SRBench-style introspection ---
+
+    @property
+    def model_(self) -> str:
+        """Symbolic expression as discovered, in normalized coordinates.
+
+        SRBench reads `model_` (or `est.model_`) to evaluate solution
+        complexity and for symbolic comparisons with the ground truth.
+        """
+        return getattr(self, "expr_", None)
+
+    @property
+    def original_model_(self) -> Optional[str]:
+        """Symbolic expression with the normalizer's affine transform stitched in.
+
+        Returns a string like `(formula(0.5*x - 1.0) - 2.3) / 0.7`. Useful
+        for quick reading; not algebraically simplified.
+        """
+        if not getattr(self, "is_fitted_", False):
+            return None
+        import re
+        n = self.normalizer_
+        x_sub = f"({n.x_a:.6g} * x + {n.x_b:.6g})"
+        # Word-boundary replace so we hit the standalone identifier `x`
+        # without touching `exp` or future identifiers that contain x.
+        formula = re.sub(r"\bx\b", x_sub, self.expr_)
+        if n.y_a == 1.0 and n.y_b == 0.0:
+            return formula
+        return f"(({formula}) - {n.y_b:.6g}) / {n.y_a:.6g}"
+
+    def get_params(self, deep: bool = True) -> dict:
+        return {
+            "max_depth": self.max_depth,
+            "n_tries": self.n_tries,
+            "method": self.method,
+            "normalize": self.normalize,
+            "n_workers": self.n_workers,
+            "auto_project": self.auto_project,
+            "success_threshold": self.success_threshold,
+            "verbose": self.verbose,
+        }
+
+    def set_params(self, **params):
+        for k, v in params.items():
+            if not hasattr(self, k):
+                raise ValueError(f"unknown parameter {k!r}")
+            setattr(self, k, v)
+        return self


### PR DESCRIPTION
Closes #6.

## Summary
- **Phase 1 — CSV CLI**: `Normalizer` class (minmax/standard/none) + `discover_csv()` + argparse subcommands. `python eml_sr.py csv data.csv --x-col t --y-col temp --max-depth 5 --workers 8` works end-to-end. Reports the formula in normalized coords plus the affine substitution needed to invert it.
- **Phase 2 — Feynman benchmark**: `benchmarks/feynman.py` with 17 curated univariate Feynman slices (genuinely-univariate equations + projections of multivariate ones at fixed constants). Both `discover` and `curriculum` paths, parallel-seed support, quick / `--all` modes.
- **Phase 3 — sklearn interface for SRBench**: `eml_sr_sklearn.EMLRegressor` exposes fit/predict/score/get_params/set_params plus `model_` (normalized) and `original_model_` (with affine substitution stitched back in). `auto_project=True` picks the highest-|Spearman| column when `X` is multivariate, so eml-sr can sit on the SRBench leaderboard for univariate / near-univariate problems while flagging the limitation cleanly for the rest.
- **Performance**: `discover(..., n_workers=N)` fans seeds out across processes via `multiprocessing.Pool` (`fork`, single-thread workers). ~5x speedup on the depth-2 `exp(x)` demo with 4 workers (10.7s → 2.1s). Wired through both the CSV CLI (`--workers`) and `EMLRegressor`.

## Key question (from the issue)
The Feynman benchmark exposes that EML's *theoretical* completeness doesn't cleanly translate to practical recovery on data with arbitrary multiplicative constants — the operator set is just `eml(x, y)` and the literal `1`, so things like `0.3 * x` or `9.81 * x` are quite deep in this representation. That's the honest finding, and it's surfaced rather than hidden.

## Test plan
- [x] `python eml_sr.py demo` — original depth-2 `exp(x)-ln(x)` recovery still passes (rmse 3.2e-16)
- [x] `python eml_sr.py csv ... --normalize none` recovers `exp(x)` exactly (rmse 1.4e-15)
- [x] `EMLRegressor` round-trip: R² = 1.0 on train, 0.0 max-abs-err on holdout for `exp(x)-ln(x)`
- [x] `original_model_` regex correctly substitutes `x` without mangling `exp` (caught & fixed during testing)
- [x] Parallel verbose mode: `imap` preserves seed order so output isn't interleaved
- [x] `discover_curriculum` smoke test still works
- [x] `python -m benchmarks.feynman --workers 8` runs cleanly end-to-end