### PR TITLE
Option B linear tree, hybrid dispatcher, warm-start, and multivariate forward pass

### DIFF
--- a/benchmarks/feynman.py
+++ b/benchmarks/feynman.py
@@ -27,17 +27,20 @@ random init. The current selection keeps:
   - exp / ln chains (EML's natural wheelhouse)
   - The depth-1 EML shape eml(x, x) = exp(x) - ln(x)
 
-The defaults were also flipped to `--method curriculum --normalize standard`
-since min-max normalization to [-1, 1] flattens curvature and pushes the
-optimizer into the `(exp(x) - 1)` local minimum for almost every nonlinear
-target. See issue #11 for the full diagnosis.
+The defaults were also flipped to `--method curriculum --normalize none`.
+Both `minmax` and `standard` normalization destroy symbolic recoverability
+for nonlinear targets — the affine transform of an elementary function is
+generally not itself elementary in the EML vocabulary, so the engine ends
+up fitting an unreachable shape. The runner now reports RMSE in *original*
+coordinate space (not normalized space, as the original implementation
+did, which was misleading). See issue #11 for the full diagnosis.
 
 Usage::
 
     python -m benchmarks.feynman                  # quick: 8 problems
     python -m benchmarks.feynman --all            # all problems
     python -m benchmarks.feynman --workers 8      # parallel seeds
-    python -m benchmarks.feynman --method discover --normalize minmax
+    python -m benchmarks.feynman --normalize minmax  # for huge y ranges
 """
 
 from __future__ import annotations
@@ -49,13 +52,14 @@ from dataclasses import dataclass
 from typing import Callable, Optional
 
 import numpy as np
+import torch
 
 # Allow running as a script from the repo root or as `python -m benchmarks.feynman`.
 import sys
 import os
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from eml_sr import discover, discover_curriculum, Normalizer  # noqa: E402
+from eml_sr import REAL, discover, discover_curriculum, Normalizer  # noqa: E402
 
 
 # ─── Problem catalogue ─────────────────────────────────────────
@@ -199,22 +203,42 @@ def _run_one(prob: FeynmanProblem, *, max_depth: int, n_tries: int,
 
     if result is None:
         return {"prob": prob, "ok": False, "expr": None, "elapsed": elapsed,
-                "rmse": float("inf"), "depth": None}
+                "rmse": float("inf"), "rmse_norm": float("inf"), "depth": None}
+
+    # Recompute RMSE in *original* coordinate space — `result["snap_rmse"]`
+    # is reported in normalized space, which is misleading: an affine
+    # transform of an elementary target (minmax/standard) is generally
+    # not itself elementary in the EML vocabulary, so a perfect-RMSE fit
+    # in normalized space corresponds to a *bad* fit in original space.
+    # Issue #11 documents the implications.
+    snapped = result.get("snapped_tree")
+    rmse_orig = float("inf")
+    if snapped is not None:
+        with torch.no_grad():
+            pred_n, _, _ = snapped(torch.tensor(x_n, dtype=REAL), tau=0.01)
+            pred_n_np = pred_n.real.detach().numpy()
+            pred_orig = norm.inverse_y(pred_n_np)
+            rmse_orig = float(np.sqrt(np.mean((pred_orig - y) ** 2)))
 
     return {
         "prob": prob,
         "ok": bool(result.get("exact", True)),
         "expr": result["expr"],
-        "rmse": result["snap_rmse"],
+        "rmse": rmse_orig,
+        "rmse_norm": result["snap_rmse"],
         "depth": result["depth"],
         "elapsed": elapsed,
         "normalizer": norm,
     }
 
 
-def _fmt_row(r: dict) -> str:
+def _fmt_row(r: dict, threshold: float) -> str:
     p = r["prob"]
-    ok = "✓" if r["ok"] else " "
+    # Recovery is "ok" only when the original-space RMSE is below threshold.
+    # The discover()-internal "exact" flag is computed against the
+    # normalized-space MSE which can be misleading (issue #11).
+    is_ok = math.isfinite(r["rmse"]) and r["rmse"] < threshold
+    ok = "✓" if is_ok else " "
     rmse = "—" if not math.isfinite(r["rmse"]) else f"{r['rmse']:.2e}"
     depth = "—" if r["depth"] is None else str(r["depth"])
     expr = (r["expr"] or "<no formula>")[:42]
@@ -225,6 +249,7 @@ def _fmt_row(r: dict) -> str:
 def run(quick: bool = True, **kwargs) -> list:
     """Run the Feynman benchmark and return a list of result dicts."""
     problems = PROBLEMS[:8] if quick else PROBLEMS
+    threshold = kwargs.get("threshold", 1e-6)
 
     print(f"═══ Feynman benchmark — {len(problems)} problems "
           f"({kwargs.get('method', 'discover')}, "
@@ -238,9 +263,13 @@ def run(quick: bool = True, **kwargs) -> list:
     for prob in problems:
         r = _run_one(prob, **kwargs)
         results.append(r)
-        print(_fmt_row(r))
+        # RMSE in the printed row is now in *original* coordinate space
+        # (issue #11). Recovery counts only succeed when that original-space
+        # RMSE is below the user-supplied threshold.
+        print(_fmt_row(r, threshold=threshold))
 
-    n_ok = sum(1 for r in results if r["ok"])
+    n_ok = sum(1 for r in results
+               if math.isfinite(r["rmse"]) and r["rmse"] < threshold)
     print()
     print(f"  exact recovery:  {n_ok}/{len(results)}  "
           f"({100*n_ok/len(results):.0f}%)")
@@ -253,13 +282,19 @@ def main():
     p.add_argument("--all", action="store_true", help="Run all problems (else first 8)")
     p.add_argument("--max-depth", type=int, default=4)
     p.add_argument("--tries", type=int, default=8)
-    # Defaults retuned in issue #11: curriculum + standard normalization
-    # recover meaningfully more nonlinear targets than the original
-    # discover + minmax pairing.
+    # Defaults retuned in issue #11. Key finding: ANY normalization (minmax
+    # or standard) destroys symbolic recoverability for nonlinear targets,
+    # because the affine transform of an elementary function is generally
+    # not itself elementary in the EML vocabulary. The trimmed catalog uses
+    # modest x ranges so `none` does not overflow the EML clamp. Use
+    # `--normalize minmax` only when the y range spans many decades.
     p.add_argument("--method", choices=["discover", "curriculum"], default="curriculum")
-    p.add_argument("--normalize", choices=["minmax", "standard", "none"], default="standard")
+    p.add_argument("--normalize", choices=["minmax", "standard", "none"], default="none")
     p.add_argument("--workers", type=int, default=1)
-    p.add_argument("--threshold", type=float, default=1e-10)
+    # Threshold is on *original-space* RMSE, not normalized-space MSE.
+    # 1e-6 is the threshold for "exactly recovered" given float64 precision
+    # over reasonable y-magnitudes; anything higher is an approximation.
+    p.add_argument("--threshold", type=float, default=1e-6)
     args = p.parse_args()
 
     run(

--- a/benchmarks/feynman.py
+++ b/benchmarks/feynman.py
@@ -16,12 +16,28 @@ real Feynman CSVs are 1M+ rows each and most pertain to the multivariate
 case. The synthetic generators here use the identical functional forms
 listed in the Feynman Lectures, drawn over physically reasonable ranges.
 
+The catalogue was retuned in issue #11 after the original (issue #6) run
+revealed that polynomial/rational targets like 1/x², 2x/(1+x²), and the
+gaussian sit far outside EML's reachable vocabulary at depth ≤ 5 from
+random init. The current selection keeps:
+
+  - Linear targets (which expose the depth-1 identity-gap finding —
+    EML cannot output `y = x` until depth ≥ 4 because every output is
+    wrapped in an outer `eml(·,·)`)
+  - exp / ln chains (EML's natural wheelhouse)
+  - The depth-1 EML shape eml(x, x) = exp(x) - ln(x)
+
+The defaults were also flipped to `--method curriculum --normalize standard`
+since min-max normalization to [-1, 1] flattens curvature and pushes the
+optimizer into the `(exp(x) - 1)` local minimum for almost every nonlinear
+target. See issue #11 for the full diagnosis.
+
 Usage::
 
     python -m benchmarks.feynman                  # quick: 8 problems
     python -m benchmarks.feynman --all            # all problems
     python -m benchmarks.feynman --workers 8      # parallel seeds
-    python -m benchmarks.feynman --method curriculum
+    python -m benchmarks.feynman --method discover --normalize minmax
 """
 
 from __future__ import annotations
@@ -86,95 +102,70 @@ def _projection_const(c):
 # "Projection" means a multivariate equation evaluated at fixed constants.
 
 PROBLEMS: list[FeynmanProblem] = [
-    # ── Genuinely univariate ────────────────────────────────────
+    # ── EML's natural vocabulary (depth 1) ──────────────────────
     FeynmanProblem(
-        "I.6.2", "gaussian", "exp(-x^2 / 2) / sqrt(2*pi)",
-        _gaussian, x_range=(-2.0, 2.0),
-        notes="standard normal pdf, depth ≥ 4 (squaring + exp + scale)",
+        "eml.exp", "exp", "exp(x)",
+        lambda x: np.exp(x), x_range=(0.5, 2.5),
+        notes="depth-1 atom: eml(x, 1) = exp(x)",
     ),
     FeynmanProblem(
-        "I.6.20a", "gaussian-sigma1", "exp(-x^2/2)",
-        lambda x: np.exp(-x ** 2 / 2), x_range=(-2.0, 2.0),
+        "eml.eml", "exp-minus-ln", "exp(x) - ln(x)",
+        lambda x: np.exp(x) - np.log(x), x_range=(0.5, 3.0),
+        notes="depth-1 atom: the raw eml(x, x) shape",
     ),
     FeynmanProblem(
-        "I.27.6", "lens-thin", "1/x", lambda x: 1.0 / x,
-        x_range=(0.5, 3.0),
+        "eml.const-e", "constant-e", "e",
+        _projection_const(math.e), x_range=(0.5, 2.5),
+        notes="depth-1 atom: eml(1, 1) = e",
     ),
     FeynmanProblem(
-        "I.34.8", "doppler-low", "x", lambda x: x.copy(), x_range=(0.5, 3.0),
-        notes="trivial identity baseline",
-    ),
-    FeynmanProblem(
-        "I.34.27", "photon-momentum", "1.0545718e-34 * x",
-        lambda x: 1.0545718e-34 * x, x_range=(1e14, 1e15),
-        notes="extreme-scale linear; tests normalization",
+        "eml.e-ln", "e-minus-ln", "e - ln(x)",
+        lambda x: math.e - np.log(x), x_range=(0.5, 3.0),
+        notes="depth-1 atom: eml(1, x)",
     ),
 
-    # ── Projections of common multivariate Feynman eqs ──────────
+    # ── exp / ln chains (EML's wheelhouse) ──────────────────────
     FeynmanProblem(
-        "I.12.1", "friction", "0.3 * x", lambda x: 0.3 * x,
-        x_range=(0.0, 5.0),
-        notes="μ*F_n with μ=0.3 fixed",
+        "eml.lnx", "ln", "ln(x)",
+        lambda x: np.log(x), x_range=(0.5, 5.0),
+        notes="known to require depth 3 for exact recovery",
     ),
     FeynmanProblem(
-        "I.12.4", "coulomb-r", "1 / x^2", lambda x: 1.0 / (x ** 2),
+        "eml.expexp", "exp-of-exp", "exp(exp(x))",
+        lambda x: np.exp(np.exp(x)), x_range=(-1.0, 0.5),
+        notes="depth-2 nested exp; curriculum often beats fixed search",
+    ),
+    FeynmanProblem(
+        "eml.expexpexp", "exp-of-exp-of-exp", "exp(exp(exp(x)))",
+        lambda x: np.exp(np.exp(np.exp(x))), x_range=(-1.0, 0.3),
+        notes="depth-3 nested exp; curriculum-only territory",
+    ),
+    FeynmanProblem(
+        "eml.exp-1", "exp-minus-1", "exp(x) - 1",
+        lambda x: np.exp(x) - 1.0, x_range=(0.0, 2.0),
+        notes="depth-2: eml(x, e) — also the dominant local minimum",
+    ),
+
+    # ── Linear targets (Feynman: friction, potential, photon) ───
+    # These exist primarily to exercise the depth-1 identity-gap finding
+    # from issue #11: EML cannot emit `y = x` until depth ≥ 4 because
+    # every output is wrapped in an outer eml(·,·). When these "succeed"
+    # it is at depth 4 and only because the simplifier collapses a
+    # multi-eml chain back to `x`.
+    FeynmanProblem(
+        "I.34.8", "doppler-low", "x", lambda x: x.copy(),
         x_range=(0.5, 3.0),
-        notes="Coulomb law in r with q1*q2/(4πε0)=1",
+        notes="identity baseline; expected to need depth ≥ 4 (issue #11)",
+    ),
+    FeynmanProblem(
+        "I.12.1", "friction", "0.3 * x", lambda x: 0.3 * x,
+        x_range=(0.5, 5.0),
+        notes="μ*F_n with μ=0.3 fixed; relies on normalizer to absorb scale",
     ),
     FeynmanProblem(
         "I.14.3", "potential-mgz", "9.81 * x", lambda x: 9.81 * x,
-        x_range=(0.0, 10.0),
+        x_range=(0.5, 10.0),
         notes="gravitational PE, m=1 kg",
-    ),
-    FeynmanProblem(
-        "I.16.6", "rel-velocity", "2*x / (1 + x*x)",
-        lambda x: 2 * x / (1 + x * x),
-        x_range=(-0.9, 0.9),
-        notes="velocity addition (v1=v2=x in c=1 units)",
-    ),
-    FeynmanProblem(
-        "I.25.13", "voltage-q", "x / 1e-6", lambda x: x / 1e-6,
-        x_range=(1e-9, 1e-7),
-        notes="V = q/C, C=1μF, extreme-scale",
-    ),
-    FeynmanProblem(
-        "I.29.4", "wavevector", "x / 3e8", lambda x: x / 3e8,
-        x_range=(1e6, 1e9),
-        notes="ω/c → wavenumber",
-    ),
-    FeynmanProblem(
-        "I.34.10", "doppler-freq", "1 / (1 - x)",
-        lambda x: 1.0 / (1.0 - x),
-        x_range=(-0.5, 0.5),
-        notes="non-relativistic Doppler shift",
-    ),
-    FeynmanProblem(
-        "I.39.10", "kinetic-T", "1.5 * 1.380649e-23 * x",
-        lambda x: 1.5 * 1.380649e-23 * x,
-        x_range=(100.0, 600.0),
-        notes="thermal energy at temperature T",
-    ),
-    FeynmanProblem(
-        "I.41.16", "planck-rj", "2 * x", lambda x: 2 * x,
-        x_range=(1e10, 1e14),
-        notes="Rayleigh-Jeans low-freq limit (linear in ν)",
-    ),
-
-    # ── Stress tests (deeper formulas) ──────────────────────────
-    FeynmanProblem(
-        "stress.1", "exp-of-exp", "exp(exp(x))",
-        lambda x: np.exp(np.exp(x)), x_range=(-1.0, 0.5),
-        notes="depth-2 nested exp, curriculum often beats fixed search",
-    ),
-    FeynmanProblem(
-        "stress.2", "exp-minus-ln", "exp(x) - ln(x)",
-        lambda x: np.exp(x) - np.log(x), x_range=(0.5, 3.0),
-        notes="raw eml shape — should be depth 1",
-    ),
-    FeynmanProblem(
-        "stress.3", "ln-x", "ln(x)", lambda x: np.log(x),
-        x_range=(0.5, 5.0),
-        notes="known to require depth 3 for exact recovery",
     ),
 ]
 
@@ -262,8 +253,11 @@ def main():
     p.add_argument("--all", action="store_true", help="Run all problems (else first 8)")
     p.add_argument("--max-depth", type=int, default=4)
     p.add_argument("--tries", type=int, default=8)
-    p.add_argument("--method", choices=["discover", "curriculum"], default="discover")
-    p.add_argument("--normalize", choices=["minmax", "standard", "none"], default="minmax")
+    # Defaults retuned in issue #11: curriculum + standard normalization
+    # recover meaningfully more nonlinear targets than the original
+    # discover + minmax pairing.
+    p.add_argument("--method", choices=["discover", "curriculum"], default="curriculum")
+    p.add_argument("--normalize", choices=["minmax", "standard", "none"], default="standard")
     p.add_argument("--workers", type=int, default=1)
     p.add_argument("--threshold", type=float, default=1e-10)
     args = p.parse_args()

--- a/benchmarks/option_ab_compare.py
+++ b/benchmarks/option_ab_compare.py
@@ -56,14 +56,14 @@ TARGETS = [
 ]
 
 
-def _option_a(name, fn, lo, hi, max_depth, n_tries=4):
+def _option_a(name, fn, lo, hi, max_depth, n_tries=3):
     x = np.linspace(lo, hi, 30)
     y = fn(x)
     t0 = time.time()
     r = discover(x, y, max_depth=max_depth, n_tries=n_tries, verbose=False)
     elapsed = time.time() - t0
     return {
-        "best_mse": r["snap_rmse"] ** 2,  # discover() reports normalized rmse
+        "best_mse": r["snap_rmse"] ** 2,
         "snap_rmse": r["snap_rmse"],
         "expr": r["expr"],
         "depth": r["depth"],
@@ -71,9 +71,9 @@ def _option_a(name, fn, lo, hi, max_depth, n_tries=4):
     }
 
 
-def _option_b(name, fn, lo, hi, max_depth, n_tries=4):
-    """Option B: try each depth from 1 to max_depth, n_tries seeds each.
-    Return the best (smallest best_mse) result found."""
+def _option_b(name, fn, lo, hi, max_depth, n_tries=3):
+    """Option B: try each depth 1..max_depth, n_tries seeds each.
+    Return the best (smallest best_mse) result."""
     x = np.linspace(lo, hi, 30)
     y = fn(x)
     xt = torch.tensor(x, dtype=REAL)
@@ -85,19 +85,17 @@ def _option_b(name, fn, lo, hi, max_depth, n_tries=4):
         for seed in range(n_tries):
             r = _train_one_linear(
                 xt, yt, depth=depth, seed=seed,
-                search_iters=3000, snap_iters=1000,
+                search_iters=1500, snap_iters=500,
                 lam_disc_max=0.5, lr=0.01,
             )
             r["depth"] = depth
             if best is None or r["best_mse"] < best["best_mse"]:
                 best = r
-        # Early-exit: if we found a near-perfect fit at this depth, stop.
+        # Early-exit: near-perfect fit already.
         if best and best["best_mse"] < 1e-8:
             break
     elapsed = time.time() - t0
 
-    # Compute RMSE in the same coordinate space as Option A reports
-    # (target space, since neither method normalizes here).
     with torch.no_grad():
         pred, _, _ = best["tree"](xt)
         fit_rmse = float(np.sqrt(np.mean((pred.real.numpy() - y) ** 2)))
@@ -113,34 +111,37 @@ def _option_b(name, fn, lo, hi, max_depth, n_tries=4):
 
 
 def run():
-    print("═══ Option A (softmax) vs Option B (linear coeffs) ═══\n")
-    print(f"  {'target':18s}  {'A.fit':>10s}  {'A.depth':>8s}  "
-          f"{'B.fit':>10s}  {'B.snap':>10s}  {'B.depth':>8s}  notes")
-    print("  " + "─" * 95)
+    print("═══ Option A (softmax) vs Option B (linear coeffs) ═══\n", flush=True)
+    print(f"  {'target':18s}  {'A.fit':>10s}  {'A.d':>3s}  "
+          f"{'B.fit':>10s}  {'B.snap':>10s}  {'B.d':>3s}  "
+          f"{'tA':>5s}  {'tB':>5s}  notes", flush=True)
+    print("  " + "─" * 100, flush=True)
 
     for name, fn, (lo, hi), max_d_a, max_d_b in TARGETS:
-        ra = _option_a(name, fn, lo, hi, max_depth=max(max_d_a, 4))
-        rb = _option_b(name, fn, lo, hi, max_depth=max(max_d_b, 3))
+        # Per-target depth caps — don't waste time running deep ladders
+        # on targets we know stay shallow.
+        ra = _option_a(name, fn, lo, hi, max_depth=max_d_a)
+        rb = _option_b(name, fn, lo, hi, max_depth=max_d_b)
 
         a_fit = ra["snap_rmse"]
         b_fit = rb["fit_rmse"]
         b_snap = rb["snap_rmse"]
         winner = "B" if b_fit < a_fit / 10 else ("A" if a_fit < b_fit / 10 else "tie")
-        print(f"  {name:18s}  {a_fit:10.2e}  {ra['depth']:>8}  "
-              f"{b_fit:10.2e}  {b_snap:10.2e}  {rb['depth']:>8}  "
-              f"winner={winner}")
+        print(f"  {name:18s}  {a_fit:10.2e}  {ra['depth']:>3}  "
+              f"{b_fit:10.2e}  {b_snap:10.2e}  {rb['depth']:>3}  "
+              f"{ra['elapsed']:5.1f}  {rb['elapsed']:5.1f}  "
+              f"winner={winner}", flush=True)
 
-    print()
-    print("Legend:")
-    print("  A.fit  = Option A snap RMSE (clean argmax snap → final answer)")
-    print("  B.fit  = Option B *pre-snap* RMSE (numerical fit only)")
-    print("  B.snap = Option B *post-snap* RMSE (lossy per-coef snap; future work)")
-    print()
-    print("The interesting question is `B.fit` vs `A.fit` — that measures")
-    print("the architectural expressivity gap. `B.snap` being worse than `B.fit`")
-    print("just means our naive per-coefficient snap is broken; a smarter snap")
-    print("(iterative pruning, brute-force discrete search, learned snap)")
-    print("is the obvious follow-up.")
+    print(flush=True)
+    print("Legend:", flush=True)
+    print("  A.fit  = Option A post-snap RMSE (clean argmax snap = final answer)", flush=True)
+    print("  B.fit  = Option B *pre-snap* RMSE (numerical fit only)", flush=True)
+    print("  B.snap = Option B *post-snap* RMSE (per-coef rounding, lossy)", flush=True)
+    print("  tA/tB  = wall clock seconds", flush=True)
+    print(flush=True)
+    print("The interesting comparison is `B.fit` vs `A.fit` — that measures", flush=True)
+    print("the *architectural* expressivity gap. `B.snap` being worse than", flush=True)
+    print("`B.fit` just means the naive per-coefficient snap is broken.", flush=True)
 
 
 if __name__ == "__main__":

--- a/benchmarks/option_ab_compare.py
+++ b/benchmarks/option_ab_compare.py
@@ -1,0 +1,147 @@
+"""Side-by-side comparison of Option A (softmax) vs Option B (linear).
+
+Runs both architectures on a fixed set of targets that span:
+
+  * Easy targets that Option A handles well (sanity / regression check)
+  * Targets where Option A fails per the issue #11 diagnosis:
+    - `exp(x) - 1` (needs constant `e`, unreachable in Option A's depth-1 vocab)
+    - `y = x` (the identity gap — softmax cannot route through `eml(ln(x), 1)`)
+    - `0.3 * x` (linear with non-trivial scale, needs negative γ on a child)
+    - `exp(exp(exp(x)))` (the curriculum degenerate-snap case)
+
+Reports two numbers per row:
+
+  * `best_mse` — best MSE the architecture achieves during training, before
+    any snap. This measures the *fitting* power of the parameterization.
+  * `snap_rmse` — RMSE after snapping coefficients/logits to discrete choices.
+    Option A snaps via argmax (clean). Option B snaps via per-coefficient
+    rounding to the nearest named constant — this is currently lossy and
+    is documented as future work in `eml_sr_linear.py`.
+
+The point of the benchmark is to validate the **architectural** claim that
+Option B can fit targets Option A cannot. Symbolic recovery via a smarter
+snap is a separate problem.
+
+Usage::
+
+    python -m benchmarks.option_ab_compare
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import os
+import time
+
+import numpy as np
+import torch
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from eml_sr import REAL, DTYPE, discover
+from eml_sr_linear import _train_one_linear, EMLTree1DLinear
+
+
+TARGETS = [
+    # (name, fn, x_range, expected_min_depth_A, expected_min_depth_B)
+    ("exp(x)",          lambda x: np.exp(x),          (0.5, 2.5), 1, 1),
+    ("e (constant)",    lambda x: np.full_like(x, math.e), (0.5, 2.5), 1, 1),
+    ("ln(x)",           lambda x: np.log(x),          (0.5, 5.0), 3, 2),
+    ("exp(x) - ln(x)",  lambda x: np.exp(x) - np.log(x), (0.5, 3.0), 1, 1),
+    ("exp(x) - 1",      lambda x: np.exp(x) - 1.0,    (0.0, 2.0), 1, 1),  # A fails
+    ("y = x",           lambda x: x.copy(),            (0.5, 3.0), 4, 2),  # A fails
+    ("0.3 * x",         lambda x: 0.3 * x,            (0.5, 5.0), 4, 3),  # A fails
+    ("exp(exp(x))",     lambda x: np.exp(np.exp(x)),  (-1.0, 0.5), 2, 2),
+]
+
+
+def _option_a(name, fn, lo, hi, max_depth, n_tries=4):
+    x = np.linspace(lo, hi, 30)
+    y = fn(x)
+    t0 = time.time()
+    r = discover(x, y, max_depth=max_depth, n_tries=n_tries, verbose=False)
+    elapsed = time.time() - t0
+    return {
+        "best_mse": r["snap_rmse"] ** 2,  # discover() reports normalized rmse
+        "snap_rmse": r["snap_rmse"],
+        "expr": r["expr"],
+        "depth": r["depth"],
+        "elapsed": elapsed,
+    }
+
+
+def _option_b(name, fn, lo, hi, max_depth, n_tries=4):
+    """Option B: try each depth from 1 to max_depth, n_tries seeds each.
+    Return the best (smallest best_mse) result found."""
+    x = np.linspace(lo, hi, 30)
+    y = fn(x)
+    xt = torch.tensor(x, dtype=REAL)
+    yt = torch.tensor(y, dtype=DTYPE)
+
+    best = None
+    t0 = time.time()
+    for depth in range(1, max_depth + 1):
+        for seed in range(n_tries):
+            r = _train_one_linear(
+                xt, yt, depth=depth, seed=seed,
+                search_iters=3000, snap_iters=1000,
+                lam_disc_max=0.5, lr=0.01,
+            )
+            r["depth"] = depth
+            if best is None or r["best_mse"] < best["best_mse"]:
+                best = r
+        # Early-exit: if we found a near-perfect fit at this depth, stop.
+        if best and best["best_mse"] < 1e-8:
+            break
+    elapsed = time.time() - t0
+
+    # Compute RMSE in the same coordinate space as Option A reports
+    # (target space, since neither method normalizes here).
+    with torch.no_grad():
+        pred, _, _ = best["tree"](xt)
+        fit_rmse = float(np.sqrt(np.mean((pred.real.numpy() - y) ** 2)))
+
+    return {
+        "best_mse": best["best_mse"],
+        "fit_rmse": fit_rmse,
+        "snap_rmse": best["snap_rmse"],
+        "expr": best["expr"],
+        "depth": best["depth"],
+        "elapsed": elapsed,
+    }
+
+
+def run():
+    print("═══ Option A (softmax) vs Option B (linear coeffs) ═══\n")
+    print(f"  {'target':18s}  {'A.fit':>10s}  {'A.depth':>8s}  "
+          f"{'B.fit':>10s}  {'B.snap':>10s}  {'B.depth':>8s}  notes")
+    print("  " + "─" * 95)
+
+    for name, fn, (lo, hi), max_d_a, max_d_b in TARGETS:
+        ra = _option_a(name, fn, lo, hi, max_depth=max(max_d_a, 4))
+        rb = _option_b(name, fn, lo, hi, max_depth=max(max_d_b, 3))
+
+        a_fit = ra["snap_rmse"]
+        b_fit = rb["fit_rmse"]
+        b_snap = rb["snap_rmse"]
+        winner = "B" if b_fit < a_fit / 10 else ("A" if a_fit < b_fit / 10 else "tie")
+        print(f"  {name:18s}  {a_fit:10.2e}  {ra['depth']:>8}  "
+              f"{b_fit:10.2e}  {b_snap:10.2e}  {rb['depth']:>8}  "
+              f"winner={winner}")
+
+    print()
+    print("Legend:")
+    print("  A.fit  = Option A snap RMSE (clean argmax snap → final answer)")
+    print("  B.fit  = Option B *pre-snap* RMSE (numerical fit only)")
+    print("  B.snap = Option B *post-snap* RMSE (lossy per-coef snap; future work)")
+    print()
+    print("The interesting question is `B.fit` vs `A.fit` — that measures")
+    print("the architectural expressivity gap. `B.snap` being worse than `B.fit`")
+    print("just means our naive per-coefficient snap is broken; a smarter snap")
+    print("(iterative pruning, brute-force discrete search, learned snap)")
+    print("is the obvious follow-up.")
+
+
+if __name__ == "__main__":
+    run()

--- a/benchmarks/option_ab_results.txt
+++ b/benchmarks/option_ab_results.txt
@@ -1,0 +1,80 @@
+Option A (softmax) vs Option B (linear coeffs) — partial run
+═══════════════════════════════════════════════════════════════
+
+Ran via `python -m benchmarks.option_ab_compare` on the tightened
+budget (3 seeds per depth, 1500 search + 500 snap iters per seed).
+Got through 7 of 8 targets before the session wall clock expired;
+target 8 (`exp(exp(x))`) never started.
+
+The 7 completed rows are the ones that matter — they cover both
+the easy-for-A cases (sanity check) and the hard-for-A cases
+(the point of the experiment).
+
+  target                   A.fit  A.d       B.fit      B.snap  B.d     tA     tB  notes
+  ────────────────────────────────────────────────────────────────────────────────────────────────────
+  exp(x)                1.99e-16    1    7.35e-03    1.96e-01    1   15.7    7.4  winner=A
+  e (constant)          0.00e+00    1    4.41e-12    0.00e+00    1    5.8    7.4  winner=A (tie on snap)
+  ln(x)                 7.35e-17    3    2.00e-02    2.57e-02    2   42.5   17.4  winner=A
+  exp(x) - ln(x)        6.73e-01    1    1.30e-01    1.10e-01    1    5.7    7.3  winner=tie *
+  exp(x) - 1            1.00e+00    1    7.51e-03    7.51e-03    1    5.8    6.9  winner=B
+  y = x                 5.62e-01    2    9.92e-04    1.66e-02    2   74.9   16.9  winner=B
+  0.3 * x               5.24e-01    3    1.09e-03    1.82e-01    2   73.5   29.0  winner=B
+
+
+Legend:
+  A.fit  = Option A post-snap RMSE (clean argmax snap = final answer)
+  B.fit  = Option B *pre-snap* RMSE (numerical fit only)
+  B.snap = Option B *post-snap* RMSE (per-coef rounding, lossy)
+  tA/tB  = wall clock seconds
+
+
+Interpretation
+──────────────
+
+* `exp(x) - ln(x)` looks like a tie but shouldn't be — it's a
+  depth-1 EML atom that Option A recovers to machine precision
+  with `n_tries >= 4`. The tightened-budget run used only 3 seeds,
+  so Option A got unlucky on seed initialization. The test suite
+  in `tests/test_eml_sr.py::TestRecovery` proves this case is a
+  clean win for Option A at normal budgets.
+
+* On the three targets Option A architecturally cannot express at
+  depth ≤ 4 — `exp(x) - 1`, `y = x`, `0.3 * x` — Option B wins
+  decisively with 2-3 orders of magnitude lower RMSE. These are
+  the issue #11 failing cases, and the win is confirmed by direct
+  probes earlier in the session (`exp(x) - 1` → best_mse 1.17e-6
+  with 6 seeds, `y = x` → 2.4e-7 at depth 2 with 6 seeds).
+
+* On targets Option A handles well — `exp(x)`, `ln(x)`, `e` — Option
+  A beats Option B by 10-13 orders of magnitude. Option B's free
+  parameterization admits infinite equivalent non-canonical fits,
+  and without Option A's argmax-snap discipline the optimizer
+  converges polynomially to a near-fit but never commits to
+  machine-epsilon precision.
+
+* `B.snap` is uniformly worse than `B.fit` because the per-coefficient
+  rounding recipe is lossy (see the "Empirical findings / §3" section
+  in `eml_sr_linear.py`'s docstring).
+
+Dispatch implication
+────────────────────
+
+This benchmark shows a clean step function:
+
+  - Targets in Option A's depth-≤4 symbolic vocabulary → run Option A,
+    get machine-precision clean symbolic output.
+  - Targets outside that vocabulary (constants outside the EML closure,
+    identity function, linear scaling, etc.) → run Option B, get a
+    numerical near-fit but a lossy symbolic snap.
+
+The correct production strategy is:
+  1. Try Option A with its normal seed budget.
+  2. If A's post-snap RMSE is below a success threshold, return A's
+     answer (clean symbolic).
+  3. Otherwise, fall back to Option B and return a numerical fit
+     (possibly with a "symbolic best-effort" expression noted as
+     approximate).
+
+See the "Empirical findings" section of `eml_sr_linear.py` for full
+detail and the three candidate paths to fixing Option B's snap
+problem.

--- a/eml_sr.py
+++ b/eml_sr.py
@@ -36,45 +36,52 @@ def eml_op(x, y):
 # ─── Tree ──────────────────────────────────────────────────────
 
 class EMLTree1D(nn.Module):
-    """Univariate EML tree of given depth.
+    """EML tree of given depth.
 
-    Leaves: soft choice between 1 and x  (2 logits per leaf)
-    Gates:  each child input soft-routes over {1, x, child}
-            (3 logits per side, 2 sides per node)
+    Supports n_vars input variables (default 1 for backward compat).
+
+    Leaves: soft choice over {1, x₁, ..., xₙ}  (n_vars+1 logits per leaf)
+    Gates:  each child input soft-routes over {1, x₁, ..., xₙ, child}
+            (n_vars+2 logits per side, 2 sides per node)
     """
 
-    def __init__(self, depth: int, init_scale: float = 1.0):
+    def __init__(self, depth: int, n_vars: int = 1, init_scale: float = 1.0):
         super().__init__()
         self.depth = depth
+        self.n_vars = n_vars
         self.n_leaves = 2 ** depth
         self.n_internal = self.n_leaves - 1
 
-        # Leaf logits: (n_leaves, 2) — [weight_for_1, weight_for_x]
-        leaf_init = torch.randn(self.n_leaves, 2, dtype=REAL) * init_scale
+        # Leaf logits: (n_leaves, n_vars+1) — [weight_for_1, weight_for_x1, ...]
+        leaf_init = torch.randn(self.n_leaves, n_vars + 1, dtype=REAL) * init_scale
         leaf_init[:, 0] += 2.0  # bias toward constant 1
         self.leaf_logits = nn.Parameter(leaf_init)
 
-        # Gate logits: (n_internal, 2, 3) — 3-way softmax over [1, x, child]
+        # Gate logits: (n_internal, 2, n_vars+2) — softmax over [1, x1, ..., xn, child]
         # Bias toward constant 1 (safe default that triggers leaf usage below).
-        gate_init = torch.randn(self.n_internal, 2, 3, dtype=REAL) * init_scale
+        gate_init = torch.randn(self.n_internal, 2, n_vars + 2, dtype=REAL) * init_scale
         gate_init[..., 0] += 4.0
         self.gate_logits = nn.Parameter(gate_init)
 
     def forward(self, x, tau: float = 1.0):
+        # Handle both 1D (batch,) and 2D (batch, n_vars) input.
+        if x.dim() == 1:
+            x = x.unsqueeze(1)  # (batch,) → (batch, 1)
         x = x.to(DTYPE)
         batch = x.shape[0]
-        ones = torch.ones(batch, dtype=DTYPE)
+        ones = torch.ones(batch, 1, dtype=DTYPE)
 
-        # Leaf values: soft mixture of 1 and x
-        w = torch.softmax(self.leaf_logits / tau, dim=1).to(DTYPE)  # (n_leaves, 2)
-        candidates = torch.stack([ones, x], dim=1)  # (batch, 2)
+        # Leaf values: soft mixture of {1, x₁, ..., xₙ}
+        w = torch.softmax(self.leaf_logits / tau, dim=1).to(DTYPE)  # (n_leaves, n_vars+1)
+        candidates = torch.cat([ones, x], dim=1)  # (batch, n_vars+1)
         level = candidates @ w.T  # (batch, n_leaves)
 
-        # Gate probabilities: 3-way softmax per side
-        gate_probs = torch.softmax(self.gate_logits / tau, dim=-1)  # (n_internal, 2, 3)
+        # Gate probabilities: (n_vars+2)-way softmax per side
+        gate_probs = torch.softmax(self.gate_logits / tau, dim=-1)  # (n_internal, 2, n_vars+2)
 
-        x_r = x.real.unsqueeze(1)  # (batch, 1)
-        x_i = x.imag.unsqueeze(1)
+        # Precompute x real/imag for gate blending: (batch, n_vars)
+        x_r_all = x.real  # (batch, n_vars)
+        x_i_all = x.imag  # (batch, n_vars)
 
         # Bottom-up: pair children, apply gates, compute eml
         node_idx = 0
@@ -83,55 +90,52 @@ class EMLTree1D(nn.Module):
             left = level[:, 0::2]   # (batch, n_pairs)
             right = level[:, 1::2]
 
-            pg = gate_probs[node_idx:node_idx + n_pairs]  # (n_pairs, 2, 3)
-            # [p_const, p_x, p_child] for each side
-            p0l = pg[:, 0, 0].unsqueeze(0)  # (1, n_pairs)
-            p1l = pg[:, 0, 1].unsqueeze(0)
-            p2l = pg[:, 0, 2].unsqueeze(0)
-            p0r = pg[:, 1, 0].unsqueeze(0)
-            p1r = pg[:, 1, 1].unsqueeze(0)
-            p2r = pg[:, 1, 2].unsqueeze(0)
+            pg = gate_probs[node_idx:node_idx + n_pairs]  # (n_pairs, 2, n_vars+2)
 
-            # When child contribution is negligible, zero it out to avoid
-            # 0*inf = nan (since `left`/`right` may be clamped-inf).
-            mask_l = p2l > _CHILD_EPS
-            mask_r = p2r > _CHILD_EPS
-            safe_left_r = torch.where(mask_l, left.real, torch.zeros_like(left.real))
-            safe_left_i = torch.where(mask_l, left.imag, torch.zeros_like(left.imag))
-            safe_right_r = torch.where(mask_r, right.real, torch.zeros_like(right.real))
-            safe_right_i = torch.where(mask_r, right.imag, torch.zeros_like(right.imag))
-            p2l_safe = torch.where(mask_l, p2l, torch.zeros_like(p2l))
-            p2r_safe = torch.where(mask_r, p2r, torch.zeros_like(p2r))
+            # Build gate inputs for left and right sides.
+            # For each side s ∈ {0=left, 1=right}:
+            #   input = p[0]*1 + p[1]*x₁ + ... + p[n_vars]*xₙ + p[n_vars+1]*child
+            child_idx = self.n_vars + 1  # last index is child
 
-            # Soft blend over [1, x, child]
-            lr = p0l + p1l * x_r + p2l_safe * safe_left_r
-            li = p1l * x_i + p2l_safe * safe_left_i
-            rr = p0r + p1r * x_r + p2r_safe * safe_right_r
-            ri = p1r * x_i + p2r_safe * safe_right_i
+            for side, child in [(0, left), (1, right)]:
+                ps = pg[:, side, :]  # (n_pairs, n_vars+2)
 
-            # Clean bypass when a single choice has essentially all the mass.
-            # This matters at low tau for exact snapping.
-            bl_to_1 = p0l > _BYPASS
-            bl_to_x = p1l > _BYPASS
-            br_to_1 = p0r > _BYPASS
-            br_to_x = p1r > _BYPASS
+                # Child contribution with safe zeroing
+                p_child = ps[:, child_idx].unsqueeze(0)  # (1, n_pairs)
+                mask_c = p_child > _CHILD_EPS
+                safe_child_r = torch.where(mask_c, child.real,
+                                           torch.zeros_like(child.real))
+                safe_child_i = torch.where(mask_c, child.imag,
+                                           torch.zeros_like(child.imag))
+                p_child_safe = torch.where(mask_c, p_child,
+                                           torch.zeros_like(p_child))
 
-            ones_lr = torch.ones_like(lr)
-            zeros_li = torch.zeros_like(li)
-            x_r_b = x_r.expand_as(lr)
-            x_i_b = x_i.expand_as(li)
+                # Start with constant term
+                p_const = ps[:, 0].unsqueeze(0)  # (1, n_pairs)
+                blend_r = p_const + p_child_safe * safe_child_r
+                blend_i = p_child_safe * safe_child_i
 
-            lr = torch.where(bl_to_1, ones_lr, lr)
-            li = torch.where(bl_to_1, zeros_li, li)
-            lr = torch.where(bl_to_x, x_r_b, lr)
-            li = torch.where(bl_to_x, x_i_b, li)
-            rr = torch.where(br_to_1, ones_lr, rr)
-            ri = torch.where(br_to_1, zeros_li, ri)
-            rr = torch.where(br_to_x, x_r_b, rr)
-            ri = torch.where(br_to_x, x_i_b, ri)
+                # Add variable contributions
+                for v in range(self.n_vars):
+                    p_v = ps[:, v + 1].unsqueeze(0)  # (1, n_pairs)
+                    blend_r = blend_r + p_v * x_r_all[:, v:v+1]  # (batch, n_pairs)
+                    blend_i = blend_i + p_v * x_i_all[:, v:v+1]
 
-            left_in = torch.complex(lr, li)
-            right_in = torch.complex(rr, ri)
+                # Clean bypass when a single choice has all the mass.
+                b_to_1 = p_const > _BYPASS
+                blend_r = torch.where(b_to_1, torch.ones_like(blend_r), blend_r)
+                blend_i = torch.where(b_to_1, torch.zeros_like(blend_i), blend_i)
+                for v in range(self.n_vars):
+                    b_to_xv = ps[:, v + 1].unsqueeze(0) > _BYPASS
+                    xv_r = x_r_all[:, v:v+1].expand_as(blend_r)
+                    xv_i = x_i_all[:, v:v+1].expand_as(blend_i)
+                    blend_r = torch.where(b_to_xv, xv_r, blend_r)
+                    blend_i = torch.where(b_to_xv, xv_i, blend_i)
+
+                if side == 0:
+                    left_in = torch.complex(blend_r, blend_i)
+                else:
+                    right_in = torch.complex(blend_r, blend_i)
 
             level = eml_op(left_in, right_in)
 
@@ -154,13 +158,13 @@ class EMLTree1D(nn.Module):
         with torch.no_grad():
             k = 50.0
 
-            # Leaves: argmax over 2 options
+            # Leaves: argmax over n_vars+1 options
             lc = torch.argmax(tree.leaf_logits, dim=1)
             new_leaf = torch.full_like(tree.leaf_logits, -k)
             new_leaf[torch.arange(tree.n_leaves), lc] = k
             tree.leaf_logits.copy_(new_leaf)
 
-            # Gates: argmax over 3 options, per side
+            # Gates: argmax over n_vars+2 options, per side
             gc = torch.argmax(tree.gate_logits, dim=-1)  # (n_internal, 2)
             new_gate = torch.full_like(tree.gate_logits, -k)
             idx = torch.arange(tree.n_internal)
@@ -169,21 +173,27 @@ class EMLTree1D(nn.Module):
             tree.gate_logits.copy_(new_gate)
         return tree
 
+    def _var_labels(self) -> list:
+        """Variable names for expression printing."""
+        if self.n_vars == 1:
+            return ["1", "x"]
+        return ["1"] + [f"x{i+1}" for i in range(self.n_vars)]
+
     def to_expr(self) -> str:
         """Extract symbolic expression from snapped tree."""
         leaf_choices = torch.argmax(self.leaf_logits, dim=1).tolist()
         gate_choices = torch.argmax(self.gate_logits, dim=-1).tolist()  # (n_internal, 2)
 
-        leaf_labels = {0: "1", 1: "x"}
-        exprs = [leaf_labels[c] for c in leaf_choices]
+        labels = self._var_labels()
+        exprs = [labels[c] for c in leaf_choices]
 
         node_idx = 0
         while len(exprs) > 1:
             new_exprs = []
             for i in range(0, len(exprs), 2):
                 lc, rc = gate_choices[node_idx]
-                left = _resolve_gate(lc, exprs[i])
-                right = _resolve_gate(rc, exprs[i + 1])
+                left = _resolve_gate(lc, exprs[i], self.n_vars)
+                right = _resolve_gate(rc, exprs[i + 1], self.n_vars)
                 new_exprs.append(f"eml({left}, {right})")
                 node_idx += 1
             exprs = new_exprs
@@ -202,12 +212,15 @@ class EMLTree1D(nn.Module):
         return n
 
 
-def _resolve_gate(choice: int, child_expr: str) -> str:
-    """Map a 3-way gate choice to the input expression."""
+def _resolve_gate(choice: int, child_expr: str, n_vars: int = 1) -> str:
+    """Map a gate choice index to the input expression.
+
+    Indices: 0 → "1", 1..n_vars → variable names, n_vars+1 → child.
+    """
     if choice == 0:
         return "1"
-    if choice == 1:
-        return "x"
+    if choice <= n_vars:
+        return "x" if n_vars == 1 else f"x{choice}"
     return child_expr
 
 

--- a/eml_sr.py
+++ b/eml_sr.py
@@ -351,10 +351,16 @@ def _train_one(
     tau_search: float = 1.0,
     tau_hard: float = 0.01,
     verbose: bool = False,
+    init_tree: Optional[nn.Module] = None,
 ) -> dict:
-    """Train one EML tree from a single random seed."""
+    """Train one EML tree from a single random seed.
+
+    If ``init_tree`` is provided, it is used instead of creating a fresh
+    ``EMLTree1D(depth)`` from the random seed. The seed still sets the
+    torch RNG for reproducibility of the training loop itself.
+    """
     torch.manual_seed(seed)
-    tree = EMLTree1D(depth)
+    tree = init_tree if init_tree is not None else EMLTree1D(depth)
     opt = torch.optim.Adam(tree.parameters(), lr=lr)
 
     best_loss = float("inf")

--- a/eml_sr_hybrid.py
+++ b/eml_sr_hybrid.py
@@ -34,7 +34,7 @@ import numpy as np
 import torch
 
 from eml_sr import DTYPE, REAL, discover
-from eml_sr_linear import discover_linear
+from eml_sr_linear import discover_linear, iterative_snap, _train_one_linear
 
 
 def discover_hybrid(
@@ -97,39 +97,56 @@ def discover_hybrid(
         print(f"  Above threshold {fallback_threshold:.0e}, "
               f"falling back to Option B.")
 
-    # ── Stage 2: Option B ──────────────────────────────────────
+    # ── Stage 2: Option B (train + iterative snap) ─────────────
     if verbose:
-        print("\n═══ Stage 2: Option B (linear coefficients) ═══")
+        print("\n═══ Stage 2: Option B (linear coefficients "
+              "+ iterative snap) ═══")
 
-    result_b = discover_linear(
-        x, y,
-        max_depth=max_depth_b,
-        n_tries=n_tries_b,
-        verbose=verbose,
-    )
+    x_t = torch.tensor(x, dtype=REAL)
+    y_t = torch.tensor(y, dtype=DTYPE)
 
-    if result_b is None:
-        # Both failed; return Option A's best attempt.
+    best_b = None
+    for depth in range(1, max_depth_b + 1):
+        for seed in range(n_tries_b):
+            r = _train_one_linear(x_t, y_t, depth=depth, seed=seed,
+                                  search_iters=3000, snap_iters=10,
+                                  lam_disc_max=0.0)
+            r["depth"] = depth
+            if best_b is None or r["best_mse"] < best_b["best_mse"]:
+                best_b = r
+        if best_b and best_b["best_mse"] < 1e-5:
+            break
+
+    if best_b is None:
         if result_a is not None:
             result_a["method"] = "option_a"
             return result_a
         return None
 
-    # Compute the *pre-snap* RMSE on the original data to show the
-    # architecture's true fitting power (separate from snap quality).
-    x_t = torch.tensor(x, dtype=REAL)
+    # Iterative snap: prune one coefficient at a time, retrain.
+    if verbose:
+        print(f"\n  B free fit: mse={best_b['best_mse']:.2e} "
+              f"(depth {best_b['depth']})")
+        print("  Running iterative snap...")
+
+    snapped_tree = iterative_snap(
+        best_b["tree"], x_t, y_t,
+        retrain_iters=300, lr=0.005,
+        verbose=verbose,
+    )
+
     with torch.no_grad():
-        tree = result_b.get("snapped_tree")
-        if tree is not None:
-            # Use the un-snapped tree for fit_rmse if available.
-            pred, _, _ = tree(x_t)
-            fit_rmse = float(np.sqrt(np.mean(
-                (pred.real.detach().numpy() - y) ** 2)))
-        else:
-            fit_rmse = result_b["snap_rmse"]
+        pred, _, _ = snapped_tree(x_t)
+        b_rmse = float(np.sqrt(np.mean(
+            (pred.real.detach().numpy() - y) ** 2)))
+
+    b_expr = snapped_tree.to_expr()
+
+    if verbose:
+        print(f"\n  B iterative snap: rmse={b_rmse:.2e}")
+        print(f"  expr: {b_expr[:80]}")
 
     # Pick the better result between A and B.
-    b_rmse = result_b["snap_rmse"]
     if a_rmse < b_rmse and result_a is not None:
         if verbose:
             print(f"\n  Option A still wins on snap RMSE "
@@ -138,11 +155,13 @@ def discover_hybrid(
         return result_a
 
     if verbose:
-        print(f"\n  ✓ Option B wins: snap_rmse={b_rmse:.2e} "
-              f"fit_rmse={fit_rmse:.2e}")
-        print(f"    depth={result_b['depth']} "
-              f"expr={result_b['expr'][:80]}")
+        print(f"\n  ✓ Option B wins: rmse={b_rmse:.2e}")
 
-    result_b["method"] = "option_b"
-    result_b["fit_rmse"] = fit_rmse
-    return result_b
+    return {
+        "expr": b_expr,
+        "depth": best_b["depth"],
+        "snap_rmse": b_rmse,
+        "snapped_tree": snapped_tree,
+        "method": "option_b",
+        "fit_rmse": best_b["best_mse"] ** 0.5,
+    }

--- a/eml_sr_hybrid.py
+++ b/eml_sr_hybrid.py
@@ -1,0 +1,148 @@
+"""discover_hybrid: staged Option A → Option B formula discovery.
+
+Tries Option A (softmax/argmax, clean symbolic output) first. If A's
+post-snap RMSE exceeds a threshold, falls back to Option B (linear
+coefficients, more expressive, lossy symbolic snap).
+
+This is Strategy 1 from the issue #11 / Option B investigation:
+
+    (x, y)  →  Option A (fast, clean symbolic)
+            →  Option B fallback (slower, numerical fit)
+            →  return best result with a flag showing which stage won
+
+The user sees one API (`discover_hybrid`) and gets:
+  - Clean symbolic output when Option A succeeds
+  - A numerical near-fit when Option A fails architecturally
+  - A `method` field indicating which stage produced the answer
+
+Usage::
+
+    from eml_sr_hybrid import discover_hybrid
+
+    result = discover_hybrid(x, y)
+    print(result["expr"], result["method"])
+    # → 'exp(x)'  'option_a'          (clean symbolic)
+    # → 'eml(...)'  'option_b'        (numerical fit)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+
+from eml_sr import DTYPE, REAL, discover
+from eml_sr_linear import discover_linear
+
+
+def discover_hybrid(
+    x: np.ndarray,
+    y: np.ndarray,
+    max_depth: int = 4,
+    n_tries_a: int = 8,
+    n_tries_b: int = 4,
+    max_depth_b: int = 3,
+    fallback_threshold: float = 1e-6,
+    verbose: bool = True,
+) -> Optional[dict]:
+    """Discover a formula relating x → y, using Option A first with
+    Option B as a fallback.
+
+    Args:
+        x: input values (1D numpy array)
+        y: output values (1D numpy array)
+        max_depth: maximum tree depth for Option A (default 4)
+        n_tries_a: random seeds per depth for Option A (default 8)
+        n_tries_b: random seeds per depth for Option B (default 4)
+        max_depth_b: maximum tree depth for Option B (default 3)
+        fallback_threshold: RMSE below which Option A is accepted
+            without falling back to Option B (default 1e-6)
+        verbose: print progress
+
+    Returns:
+        dict with keys:
+            expr: symbolic expression string
+            depth: tree depth used
+            snap_rmse: RMSE of the snapped tree
+            snapped_tree: callable nn.Module
+            method: 'option_a' or 'option_b'
+            fit_rmse: (Option B only) pre-snap RMSE showing the
+                      architecture's true fitting power
+    """
+    # ── Stage 1: Option A ──────────────────────────────────────
+    if verbose:
+        print("═══ Stage 1: Option A (softmax / clean symbolic) ═══")
+
+    result_a = discover(
+        x, y,
+        max_depth=max_depth,
+        n_tries=n_tries_a,
+        verbose=verbose,
+    )
+
+    if result_a is not None and result_a["snap_rmse"] < fallback_threshold:
+        if verbose:
+            print(f"\n  ✓ Option A succeeded: {result_a['expr']}")
+            print(f"    depth={result_a['depth']} "
+                  f"rmse={result_a['snap_rmse']:.2e}")
+        result_a["method"] = "option_a"
+        return result_a
+
+    a_rmse = result_a["snap_rmse"] if result_a else float("inf")
+    a_expr = result_a["expr"] if result_a else None
+    if verbose:
+        print(f"\n  Option A best: rmse={a_rmse:.2e} → {a_expr}")
+        print(f"  Above threshold {fallback_threshold:.0e}, "
+              f"falling back to Option B.")
+
+    # ── Stage 2: Option B ──────────────────────────────────────
+    if verbose:
+        print("\n═══ Stage 2: Option B (linear coefficients) ═══")
+
+    result_b = discover_linear(
+        x, y,
+        max_depth=max_depth_b,
+        n_tries=n_tries_b,
+        verbose=verbose,
+    )
+
+    if result_b is None:
+        # Both failed; return Option A's best attempt.
+        if result_a is not None:
+            result_a["method"] = "option_a"
+            return result_a
+        return None
+
+    # Compute the *pre-snap* RMSE on the original data to show the
+    # architecture's true fitting power (separate from snap quality).
+    x_t = torch.tensor(x, dtype=REAL)
+    with torch.no_grad():
+        tree = result_b.get("snapped_tree")
+        if tree is not None:
+            # Use the un-snapped tree for fit_rmse if available.
+            pred, _, _ = tree(x_t)
+            fit_rmse = float(np.sqrt(np.mean(
+                (pred.real.detach().numpy() - y) ** 2)))
+        else:
+            fit_rmse = result_b["snap_rmse"]
+
+    # Pick the better result between A and B.
+    b_rmse = result_b["snap_rmse"]
+    if a_rmse < b_rmse and result_a is not None:
+        if verbose:
+            print(f"\n  Option A still wins on snap RMSE "
+                  f"({a_rmse:.2e} < {b_rmse:.2e})")
+        result_a["method"] = "option_a"
+        return result_a
+
+    if verbose:
+        print(f"\n  ✓ Option B wins: snap_rmse={b_rmse:.2e} "
+              f"fit_rmse={fit_rmse:.2e}")
+        print(f"    depth={result_b['depth']} "
+              f"expr={result_b['expr'][:80]}")
+
+    result_b["method"] = "option_b"
+    result_b["fit_rmse"] = fit_rmse
+    return result_b

--- a/eml_sr_hybrid.py
+++ b/eml_sr_hybrid.py
@@ -33,8 +33,61 @@ from typing import Optional
 import numpy as np
 import torch
 
-from eml_sr import DTYPE, REAL, discover
-from eml_sr_linear import discover_linear, iterative_snap, _train_one_linear
+from eml_sr import DTYPE, REAL, EMLTree1D, _train_one, discover
+from eml_sr_linear import (
+    EMLTree1DLinear, discover_linear, iterative_snap, _train_one_linear,
+)
+
+
+def warm_start_a_from_b(
+    b_tree: EMLTree1DLinear,
+    bias: float = 4.0,
+) -> EMLTree1D:
+    """Create an Option A tree with logits biased from Option B's coefficients.
+
+    For each leaf ``(α, β)`` in B, the A leaf logit for ``{1, x}`` is biased
+    toward whichever has the larger absolute coefficient. For each gate side
+    ``(α, β, γ)`` in B, the A gate logit for ``{1, x, child}`` is biased
+    toward the dominant contributor.
+
+    This gives Option A a warm start from B's structural exploration, so
+    A's tau-anneal training can commit to a discrete structure faster and
+    with fewer random seeds (issue #12).
+
+    Args:
+        b_tree: a trained EMLTree1DLinear (not modified)
+        bias: strength of the logit bias (default 4.0; higher = more
+            confident warm start, lower = more exploration room)
+
+    Returns:
+        A new EMLTree1D with biased logits, ready for training.
+    """
+    depth = b_tree.depth
+    a_tree = EMLTree1D(depth, init_scale=0.0)
+
+    with torch.no_grad():
+        # ── Leaves: (n_leaves, 2) ──
+        # B stores [α (constant), β (x)]. Bias A toward whichever is larger.
+        b_leaf = b_tree.leaf_logits.detach()  # (n_leaves, 2)
+        abs_leaf = b_leaf.abs()
+        dominant = torch.argmax(abs_leaf, dim=1)  # 0 → constant, 1 → x
+        new_leaf = torch.full_like(a_tree.leaf_logits, -bias)
+        new_leaf[torch.arange(a_tree.n_leaves), dominant] = bias
+        a_tree.leaf_logits.copy_(new_leaf)
+
+        # ── Gates: (n_internal, 2, 3) ──
+        # B stores [α (constant), β (x), γ (child)] per side.
+        # Bias A's 3-way softmax logit toward the dominant contributor.
+        b_gate = b_tree.gate_logits.detach()  # (n_internal, 2, 3)
+        abs_gate = b_gate.abs()
+        dominant_gate = torch.argmax(abs_gate, dim=-1)  # (n_internal, 2)
+        new_gate = torch.full_like(a_tree.gate_logits, -bias)
+        idx = torch.arange(a_tree.n_internal)
+        for side in range(2):
+            new_gate[idx, side, dominant_gate[:, side]] = bias
+        a_tree.gate_logits.copy_(new_gate)
+
+    return a_tree
 
 
 def discover_hybrid(
@@ -95,15 +148,77 @@ def discover_hybrid(
     if verbose:
         print(f"\n  Option A best: rmse={a_rmse:.2e} → {a_expr}")
         print(f"  Above threshold {fallback_threshold:.0e}, "
-              f"falling back to Option B.")
+              f"trying warm-start from Option B.")
+
+    x_t = torch.tensor(x, dtype=REAL)
+    y_t = torch.tensor(y, dtype=DTYPE)
+
+    # ── Stage 1.5: Warm-start A from B (issue #12) ────────────
+    # Train a quick Option B to discover structure, then bias
+    # Option A's logits from B's dominant coefficients. This gives
+    # A a better starting point without changing its architecture.
+    if verbose:
+        print("\n═══ Stage 1.5: Warm-start Option A from Option B ═══")
+
+    best_warm = None
+    for depth in range(1, max_depth_b + 1):
+        # Quick B exploration: short budget, no snap penalty.
+        for seed in range(n_tries_b):
+            b_result = _train_one_linear(
+                x_t, y_t, depth=depth, seed=seed,
+                search_iters=1500, snap_iters=0, lam_disc_max=0.0)
+
+            # Convert B's structure to A's logits and train A.
+            a_init = warm_start_a_from_b(b_result["tree"])
+            a_ws = _train_one(x_t, y_t, depth=depth, seed=seed,
+                              init_tree=a_init, verbose=False)
+
+            if verbose and a_ws["snap_rmse"] < 1e-3:
+                print(f"  d={depth} s={seed}: "
+                      f"rmse={a_ws['snap_rmse']:.2e} "
+                      f"→ {a_ws['expr'][:60]}")
+
+            if best_warm is None or a_ws["snap_mse"] < best_warm["snap_mse"]:
+                best_warm = a_ws
+                best_warm["depth"] = depth
+
+            if a_ws["snap_mse"] < fallback_threshold ** 2:
+                break
+        if best_warm and best_warm["snap_mse"] < fallback_threshold ** 2:
+            break
+
+    ws_rmse = best_warm["snap_rmse"] if best_warm else float("inf")
+    if best_warm is not None and ws_rmse < fallback_threshold:
+        if verbose:
+            print(f"\n  ✓ Warm-start A succeeded: {best_warm['expr']}")
+            print(f"    depth={best_warm['depth']} rmse={ws_rmse:.2e}")
+        return {
+            "expr": best_warm["expr"],
+            "depth": best_warm["depth"],
+            "snap_rmse": ws_rmse,
+            "snapped_tree": best_warm["snapped"],
+            "method": "warm_start_a",
+        }
+
+    if verbose:
+        print(f"\n  Warm-start A best: rmse={ws_rmse:.2e}")
+        print(f"  Falling back to full Option B.")
+
+    # Update a_rmse to include warm-start result for final comparison.
+    if ws_rmse < a_rmse:
+        a_rmse = ws_rmse
+        result_a = {
+            "expr": best_warm["expr"],
+            "depth": best_warm["depth"],
+            "snap_rmse": ws_rmse,
+            "snapped_tree": best_warm["snapped"],
+            "n_uncertain": best_warm.get("n_uncertain", 0),
+        }
 
     # ── Stage 2: Option B (train + iterative snap) ─────────────
     if verbose:
         print("\n═══ Stage 2: Option B (linear coefficients "
               "+ iterative snap) ═══")
-
-    x_t = torch.tensor(x, dtype=REAL)
-    y_t = torch.tensor(y, dtype=DTYPE)
 
     best_b = None
     for depth in range(1, max_depth_b + 1):
@@ -146,12 +261,12 @@ def discover_hybrid(
         print(f"\n  B iterative snap: rmse={b_rmse:.2e}")
         print(f"  expr: {b_expr[:80]}")
 
-    # Pick the better result between A and B.
+    # Pick the better result between A (or warm-start A) and B.
     if a_rmse < b_rmse and result_a is not None:
         if verbose:
             print(f"\n  Option A still wins on snap RMSE "
                   f"({a_rmse:.2e} < {b_rmse:.2e})")
-        result_a["method"] = "option_a"
+        result_a["method"] = result_a.get("method", "option_a")
         return result_a
 
     if verbose:

--- a/eml_sr_linear.py
+++ b/eml_sr_linear.py
@@ -213,75 +213,76 @@ class EMLTree1DLinear(nn.Module):
     """Option B EML tree with unconstrained linear gate combinations.
 
     Same shape contract as `EMLTree1D` but with paper-faithful
-    parameterization:
+    parameterization. Supports n_vars input variables (default 1).
 
-      Leaves: input = α + β·x   (2 reals per leaf)
-      Gates:  input = α + β·x + γ·child  (3 reals per side, 2 sides per node)
+      Leaves: input = α + β₁·x₁ + ... + βₙ·xₙ   (n_vars+1 reals per leaf)
+      Gates:  input = α + β₁·x₁ + ... + βₙ·xₙ + γ·child
+              (n_vars+2 reals per side, 2 sides per node)
 
     Identical parameter tensor *shapes* to `EMLTree1D`. They are *not*
     interchangeable — the values are coefficients here, not pre-softmax
     logits.
     """
 
-    def __init__(self, depth: int, init_scale: float = 0.1):
+    def __init__(self, depth: int, n_vars: int = 1, init_scale: float = 0.1):
         super().__init__()
         self.depth = depth
+        self.n_vars = n_vars
         self.n_leaves = 2 ** depth
         self.n_internal = self.n_leaves - 1
 
-        # Leaf coefficients: (n_leaves, 2) — [α (constant), β (x)]
-        # Initialize close to the depth-1 atom `α=1, β=0` (constant 1) so
-        # the tree starts as a stable constant-1 fit and the optimizer
-        # discovers structure from there.
-        leaf_init = torch.randn(self.n_leaves, 2, dtype=REAL) * init_scale
+        # Leaf coefficients: (n_leaves, n_vars+1) — [α (constant), β₁, ..., βₙ]
+        leaf_init = torch.randn(self.n_leaves, n_vars + 1, dtype=REAL) * init_scale
         leaf_init[:, 0] += 1.0  # bias α toward 1
         self.leaf_logits = nn.Parameter(leaf_init)
 
-        # Gate coefficients: (n_internal, 2, 3) — [α (constant), β (x), γ (child)]
-        # Bias γ toward 1.0 so the child contribution flows up by default;
-        # this matches Option A's behavior of "child" being the most
-        # informative source after random init.
-        gate_init = torch.randn(self.n_internal, 2, 3, dtype=REAL) * init_scale
-        gate_init[..., 2] += 1.0  # bias γ toward 1
+        # Gate coefficients: (n_internal, 2, n_vars+2) — [α, β₁, ..., βₙ, γ]
+        # Bias γ (last index) toward 1.0 so child contribution flows up.
+        gate_init = torch.randn(self.n_internal, 2, n_vars + 2, dtype=REAL) * init_scale
+        gate_init[..., -1] += 1.0  # bias γ toward 1
         self.gate_logits = nn.Parameter(gate_init)
 
     def forward(self, x, tau: float = 1.0):  # tau accepted for API parity, unused
+        # Handle both 1D (batch,) and 2D (batch, n_vars) input.
+        if x.dim() == 1:
+            x = x.unsqueeze(1)  # (batch,) → (batch, 1)
         x = x.to(DTYPE)
         batch = x.shape[0]
-        ones = torch.ones(batch, dtype=DTYPE)
 
-        # Leaf values: α + β·x (no softmax, no temperature)
-        a = self.leaf_logits[:, 0].to(DTYPE)  # (n_leaves,)
-        b = self.leaf_logits[:, 1].to(DTYPE)  # (n_leaves,)
-        # broadcast: (batch, n_leaves)
-        level = a.unsqueeze(0) * ones.unsqueeze(1) + b.unsqueeze(0) * x.unsqueeze(1)
+        # Leaf values: α + β₁·x₁ + ... + βₙ·xₙ
+        coeffs = self.leaf_logits.to(DTYPE)  # (n_leaves, n_vars+1)
+        ones = torch.ones(batch, 1, dtype=DTYPE)
+        candidates = torch.cat([ones, x], dim=1)  # (batch, n_vars+1)
+        level = candidates @ coeffs.T  # (batch, n_leaves)
 
         # Bottom-up: pair children, apply gate linear combos, compute eml
         node_idx = 0
-        x_b = x.unsqueeze(1)  # (batch, 1)
         while level.shape[1] > 1:
             n_pairs = level.shape[1] // 2
             left = level[:, 0::2]   # (batch, n_pairs), complex
             right = level[:, 1::2]
 
-            g = self.gate_logits[node_idx:node_idx + n_pairs]  # (n_pairs, 2, 3) real
+            g = self.gate_logits[node_idx:node_idx + n_pairs]  # (n_pairs, 2, n_vars+2)
             g_c = g.to(DTYPE)
-            # α, β, γ for left and right sides
-            a_l = g_c[:, 0, 0].unsqueeze(0)  # (1, n_pairs)
-            b_l = g_c[:, 0, 1].unsqueeze(0)
-            c_l = g_c[:, 0, 2].unsqueeze(0)
-            a_r = g_c[:, 1, 0].unsqueeze(0)
-            b_r = g_c[:, 1, 1].unsqueeze(0)
-            c_r = g_c[:, 1, 2].unsqueeze(0)
+            child_idx = self.n_vars + 1  # last index is γ (child coeff)
 
-            # Free linear combinations — no clamping of coefficients.
-            left_in = a_l + b_l * x_b + c_l * left
-            right_in = a_r + b_r * x_b + c_r * right
+            for side, child in [(0, left), (1, right)]:
+                gs = g_c[:, side, :]  # (n_pairs, n_vars+2)
+                # α + β₁·x₁ + ... + βₙ·xₙ
+                blend = gs[:, 0].unsqueeze(0)  # (1, n_pairs) — constant α
+                for v in range(self.n_vars):
+                    blend = blend + gs[:, v + 1].unsqueeze(0) * x[:, v:v+1]
+                # + γ·child
+                blend = blend + gs[:, child_idx].unsqueeze(0) * child
+
+                if side == 0:
+                    left_in = blend
+                else:
+                    right_in = blend
 
             level = eml_op(left_in, right_in)
 
-            # Same numerical clamp as Option A — exp/ln overflow is
-            # independent of the parameterization.
+            # Same numerical clamp as Option A.
             level = torch.complex(
                 torch.nan_to_num(level.real, nan=0.0,
                                  posinf=_CLAMP, neginf=-_CLAMP).clamp(-_CLAMP, _CLAMP),
@@ -310,6 +311,12 @@ class EMLTree1DLinear(nn.Module):
                         flat[i] = snapped
         return tree
 
+    def _var_names(self) -> list:
+        """Variable names for expression printing."""
+        if self.n_vars == 1:
+            return ["x"]
+        return [f"x{i+1}" for i in range(self.n_vars)]
+
     def to_expr(self) -> str:
         """Pretty-print the tree as a linear-combination eml expression.
 
@@ -318,24 +325,57 @@ class EMLTree1DLinear(nn.Module):
         atomic vocabulary. The printed form is therefore pre-simplification:
         readers can verify structure but the surface syntax is verbose.
         """
-        leaf_a = self.leaf_logits[:, 0].tolist()
-        leaf_b = self.leaf_logits[:, 1].tolist()
+        var_names = self._var_names()
+        leaf_coeffs = self.leaf_logits.tolist()  # (n_leaves, n_vars+1)
         gate = self.gate_logits.tolist()
 
-        # Pretty-print each leaf as α + β·x.
-        exprs = [_lin_expr(a, b, "x") for a, b in zip(leaf_a, leaf_b)]
+        # Pretty-print each leaf as α + β₁·x₁ + ... + βₙ·xₙ.
+        if self.n_vars == 1:
+            exprs = [_lin_expr(lc[0], lc[1], var_names[0])
+                     for lc in leaf_coeffs]
+        else:
+            exprs = []
+            for lc in leaf_coeffs:
+                parts = []
+                a_val = lc[0]
+                if abs(a_val) > 0.01:
+                    parts.append(_fmt_coef(a_val))
+                for v, name in enumerate(var_names):
+                    b_val = lc[v + 1]
+                    if abs(b_val) > 0.01:
+                        parts.append(f"{_fmt_coef(b_val)}*{name}")
+                exprs.append(" + ".join(parts) if parts else "0")
 
         node_idx = 0
         while len(exprs) > 1:
             new_exprs = []
             for i in range(0, len(exprs), 2):
                 left_child, right_child = exprs[i], exprs[i + 1]
-                gl = gate[node_idx]  # [[αl, βl, γl], [αr, βr, γr]]
-                left_in = _lin_expr3(gl[0][0], gl[0][1], gl[0][2],
-                                     "x", left_child)
-                right_in = _lin_expr3(gl[1][0], gl[1][1], gl[1][2],
-                                      "x", right_child)
-                new_exprs.append(f"eml({left_in}, {right_in})")
+                gl = gate[node_idx]  # [[α, β₁, ..., βₙ, γ], [...]]
+                # Build linear combination strings for each side
+                for side_idx, child_expr in [(0, left_child), (1, right_child)]:
+                    gs = gl[side_idx]
+                    if self.n_vars == 1:
+                        # Backward-compatible 3-arg form
+                        side_str = _lin_expr3(
+                            gs[0], gs[1], gs[2], var_names[0], child_expr)
+                    else:
+                        parts = []
+                        if abs(gs[0]) > 0.01:
+                            parts.append(_fmt_coef(gs[0]))
+                        for v, name in enumerate(var_names):
+                            if abs(gs[v + 1]) > 0.01:
+                                parts.append(f"{_fmt_coef(gs[v+1])}*{name}")
+                        gamma = gs[self.n_vars + 1]
+                        if abs(gamma) > 0.01:
+                            parts.append(
+                                f"{_fmt_coef(gamma)}*({child_expr})")
+                        side_str = " + ".join(parts) if parts else "0"
+                    if side_idx == 0:
+                        left_in_str = side_str
+                    else:
+                        right_in_str = side_str
+                new_exprs.append(f"eml({left_in_str}, {right_in_str})")
                 node_idx += 1
             exprs = new_exprs
         return exprs[0]

--- a/eml_sr_linear.py
+++ b/eml_sr_linear.py
@@ -528,6 +528,200 @@ def _train_one_linear(
     }
 
 
+# ─── Iterative snap (pruning) ────────────────────────────────
+#
+# The naive all-at-once snap destroys the fit because individual
+# coefficients are not independent carriers of meaning. Iterative
+# pruning snaps one coefficient at a time — smallest distance to
+# nearest named constant first — and retrains the remaining free
+# coefficients after each snap to absorb the discontinuity.
+#
+# This is the standard neural-network magnitude-pruning algorithm
+# applied to the coefficient lattice {0, ±1, ±2, ±e}.
+
+def _nearest_snap(v: float) -> tuple[float, float]:
+    """Return (snap_target, distance) for the nearest named constant."""
+    best_c, best_d = 0.0, abs(v)
+    for c, _ in _NAMED_CONSTANTS:
+        d = abs(v - c)
+        if d < best_d:
+            best_c, best_d = c, d
+    # Also check nearest integer for larger values.
+    ri = float(round(v))
+    d = abs(v - ri)
+    if d < best_d:
+        best_c, best_d = ri, d
+    return best_c, best_d
+
+
+def iterative_snap(
+    tree: EMLTree1DLinear,
+    x_data: torch.Tensor,
+    targets: torch.Tensor,
+    retrain_iters: int = 300,
+    lr: float = 0.005,
+    max_mse_ratio: float = 100.0,
+    verbose: bool = False,
+) -> EMLTree1DLinear:
+    """Iteratively snap a trained Option-B tree's coefficients.
+
+    Algorithm:
+      1. Collect all un-snapped coefficients
+      2. Find the one closest to a named constant
+      3. Snap it (set value, freeze via requires_grad mask)
+      4. Retrain remaining free coefficients for `retrain_iters` steps
+      5. If MSE blew up beyond `max_mse_ratio × initial_mse`, undo and
+         try the next-closest coefficient
+      6. Repeat until all coefficients are snapped or no more can be
+         snapped without blowing up MSE
+
+    Args:
+        tree: a trained EMLTree1DLinear (will be deep-copied)
+        x_data: training inputs (float64 tensor)
+        targets: training targets (complex128 tensor)
+        retrain_iters: gradient steps after each snap
+        lr: learning rate for retraining
+        max_mse_ratio: if MSE after retrain exceeds this × baseline,
+            reject the snap and try the next candidate
+        verbose: print each snap step
+
+    Returns:
+        A new EMLTree1DLinear with as many coefficients snapped as
+        possible without destroying the fit.
+    """
+    tree = copy.deepcopy(tree)
+
+    # Baseline MSE before any snapping.
+    with torch.no_grad():
+        pred, _, _ = tree(x_data)
+        baseline_mse = float(torch.mean((pred - targets).abs() ** 2).real.item())
+
+    if not math.isfinite(baseline_mse):
+        return tree  # nothing we can do
+
+    mse_ceiling = baseline_mse * max_mse_ratio
+
+    # Build a flat index of all coefficients: (param_name, flat_idx).
+    def _all_indices():
+        indices = []
+        for name, param in [("leaf", tree.leaf_logits),
+                            ("gate", tree.gate_logits)]:
+            flat = param.view(-1)
+            for i in range(flat.numel()):
+                indices.append((name, i))
+        return indices
+
+    frozen = set()  # (name, idx) pairs that are snapped and frozen
+    n_total = tree.leaf_logits.numel() + tree.gate_logits.numel()
+
+    for round_num in range(n_total):
+        # Collect candidates: un-frozen coefficients with their snap distance.
+        candidates = []
+        for name, idx in _all_indices():
+            if (name, idx) in frozen:
+                continue
+            param = tree.leaf_logits if name == "leaf" else tree.gate_logits
+            v = float(param.view(-1)[idx].item())
+            snap_target, dist = _nearest_snap(v)
+            candidates.append((dist, name, idx, snap_target))
+
+        if not candidates:
+            break  # all snapped
+
+        # Sort by distance — snap the "easiest" one first.
+        candidates.sort()
+
+        snapped_one = False
+        for dist, name, idx, snap_target in candidates:
+            # Save state in case we need to undo.
+            saved_state = {k: v.clone() for k, v in tree.state_dict().items()}
+
+            # Snap this coefficient.
+            param = tree.leaf_logits if name == "leaf" else tree.gate_logits
+            with torch.no_grad():
+                param.view(-1)[idx] = snap_target
+
+            frozen.add((name, idx))
+
+            # Retrain remaining free coefficients.
+            _retrain_free(tree, x_data, targets, frozen, retrain_iters, lr)
+
+            # Check MSE.
+            with torch.no_grad():
+                pred, _, _ = tree(x_data)
+                new_mse = float(torch.mean(
+                    (pred - targets).abs() ** 2).real.item())
+
+            if not math.isfinite(new_mse) or new_mse > mse_ceiling:
+                # Reject — undo and try next candidate.
+                tree.load_state_dict(saved_state)
+                frozen.discard((name, idx))
+                if verbose:
+                    print(f"  reject: {name}[{idx}]→{snap_target:.3g} "
+                          f"(mse {new_mse:.2e} > ceiling {mse_ceiling:.2e})")
+                continue
+
+            # Accept.
+            if verbose:
+                print(f"  snap: {name}[{idx}] {dist:.3g}→{snap_target:.3g} "
+                      f"mse={new_mse:.2e}")
+            # Update ceiling: allow gradual degradation but not catastrophic.
+            mse_ceiling = max(mse_ceiling, new_mse * max_mse_ratio)
+            snapped_one = True
+            break  # restart scan with updated tree
+
+        if not snapped_one:
+            if verbose:
+                print(f"  no more coefficients can be snapped "
+                      f"(round {round_num})")
+            break
+
+    if verbose:
+        n_snapped = len(frozen)
+        print(f"  iterative snap: {n_snapped}/{n_total} coefficients "
+              f"snapped")
+
+    return tree
+
+
+def _retrain_free(
+    tree: EMLTree1DLinear,
+    x_data: torch.Tensor,
+    targets: torch.Tensor,
+    frozen: set,
+    iters: int,
+    lr: float,
+):
+    """Retrain only the un-frozen coefficients for `iters` steps."""
+    opt = torch.optim.Adam(tree.parameters(), lr=lr)
+
+    for it in range(iters):
+        opt.zero_grad()
+        pred, _, _ = tree(x_data)
+        mse = torch.mean((pred - targets).abs() ** 2).real
+        if not torch.isfinite(mse):
+            break
+        mse.backward()
+        torch.nn.utils.clip_grad_norm_(tree.parameters(), 1.0)
+
+        # Zero out gradients on frozen coefficients so they don't move.
+        with torch.no_grad():
+            for name, idx in frozen:
+                param = tree.leaf_logits if name == "leaf" else tree.gate_logits
+                if param.grad is not None:
+                    param.grad.view(-1)[idx] = 0.0
+
+        opt.step()
+
+        # Re-enforce exact frozen values (Adam momentum can drift them).
+        with torch.no_grad():
+            for name, idx in frozen:
+                param = tree.leaf_logits if name == "leaf" else tree.gate_logits
+                v = float(param.view(-1)[idx].item())
+                snap_target, _ = _nearest_snap(v)
+                param.view(-1)[idx] = snap_target
+
+
 def discover_linear(
     x: np.ndarray,
     y: np.ndarray,

--- a/eml_sr_linear.py
+++ b/eml_sr_linear.py
@@ -71,14 +71,105 @@ That's intentional scope control: the experiment's job is to answer
 full symbolic-recovery pipeline. If the answer is yes, simplifier
 extension is a follow-up issue.
 
+## Empirical findings from the prototype
+
+Runs via `benchmarks/option_ab_compare.py` and direct `_train_one_linear`
+calls surfaced three separable phenomena:
+
+### 1. Architectural expressivity: Option B wins where it should
+
+On targets Option A cannot express at a given depth, Option B fits them
+by orders of magnitude better even with *free* coefficients (before any
+snap attempt):
+
+    exp(x) - 1   (depth 1, 6 seeds)
+      Option A: rmse 1.00   (snaps to `exp(x)`, off by 1 constant)
+      Option B: best_mse 1.17e-06   (4 of 6 seeds converge)
+
+    y = x        (identity target, which Option A cannot reach at d≤4)
+      Option A: rmse 0.56  at d=3   (snaps to `e - ln(e - ln(x))`)
+      Option B: best_mse 2.4e-07 at d=2   (5 of 6 seeds converge)
+      This confirms the theoretical prediction that Option B unlocks
+      `eml(ln(x), 1) = x` via the construction
+          gate_l = 1 − eml(0, x)
+      which requires γ = −1 on the child — impossible under softmax.
+
+The 6-order-of-magnitude improvement on `exp(x) - 1` and ~6-order
+improvement on `y = x` prove the architectural claim. Option B
+strictly dominates Option A in representational power on the targets
+where Option A fails.
+
+### 2. Fitting regression on targets Option A handles well
+
+On targets Option A already nails to machine precision (`exp(x)`, `e`,
+`ln(x)`, `exp(x) - ln(x)`), Option B is *slower* and fits *worse*:
+
+    target         Option A (rmse)   Option B (best_mse)
+    exp(x)         1.99e-16           ~1e-06    (stops at near-fit)
+    ln(x)          7.35e-17           ~1e-05    (stops at near-fit)
+    e              0.00               ~1e-13    (only this one matches)
+
+Root cause: **Option B's free parameterization admits infinite
+equivalent representations of the same function**. With leaves
+`α + βx` and gates `α + βx + γ·child`, there are more free parameters
+than degrees of freedom in the target. The optimizer converges
+polynomially to near-fits but never commits to the canonical
+sparse representation. This is the dual of Option A's problem —
+Option A has a discrete, one-hot snap at the cost of expressivity;
+Option B has continuous expressivity at the cost of committing to
+any specific discrete structure.
+
+### 3. Symbolic snap is broken for Option B
+
+Per-coefficient rounding to `{0, ±1, ±2, ±e}` destroys the fit in
+every non-trivial case, because individual coefficients are not
+*independent* carriers of meaning — their *combined* value is what
+matters. A linear combo like `0.5·1 + 0.5·x + 0.7·child` may fit
+perfectly but no single coefficient is close to a named constant.
+
+A **discreteness penalty** (nearest-point loss toward the lattice
+`{0, ±1, ±2, ±e}`, applied in the second training phase) failed to
+fix this even at λ=100. The optimizer sits at saddle points on the
+Voronoi boundaries between constants; no single coefficient wants
+to move because any movement makes the penalty worse.
+
+## Implications
+
+Option B is the correct **architecture** (matches the paper, unlocks
+the targets Option A fails on) but the naive snap recipe is the
+wrong **algorithm**. Three paths forward, in increasing order of
+ambition:
+
+  * **Iterative magnitude pruning**: snap one coefficient at a time,
+    smallest-magnitude first, retrain briefly after each snap to
+    absorb the discontinuity. Classic neural-network pruning
+    technique. Probably tractable but has N×M outer iterations.
+
+  * **Brute-force discrete search**: at training's end, enumerate
+    all 2^k snap configurations over the k coefficients that are
+    "close enough" to multiple constants, evaluate MSE on each,
+    pick the best. Tractable for depth ≤ 3 (k ≈ 10–30).
+
+  * **Learned snap network**: train a separate head that, given
+    the final tree's coefficients, predicts which configuration
+    of discrete choices minimizes MSE. More complex but
+    differentiable end-to-end.
+
+The empirical conclusion: **Option B is worth pursuing**, but not
+by simply flipping the default in `eml_sr.py`. It needs either
+(a) its own training + snap pipeline that matches the paper
+properly, or (b) a hybrid that uses Option A's argmax discipline
+for targets it can handle and falls back to Option B only for
+targets where A provably cannot express the answer.
+
 ## Limitations of this prototype
 
   * No multi-process worker support (single-threaded only).
   * No curriculum learning. Random init at fixed depths.
-  * Snap-to-symbolic is best-effort — non-canonical expressions may
-    print as numeric coefficients.
-  * Only tested on the issue #11 failing targets; broader regression
-    coverage lives in `tests/test_eml_sr.py` and pertains to Option A.
+  * Snap-to-symbolic is broken for non-trivial cases; see §3 above.
+  * Only tested on a small set of targets from issue #11. Broader
+    regression coverage lives in `tests/test_eml_sr.py` and pertains
+    to Option A.
 
 ## Reference
 

--- a/eml_sr_linear.py
+++ b/eml_sr_linear.py
@@ -1,0 +1,493 @@
+"""eml_sr_linear: Option B (paper-faithful) tree for EML symbolic regression.
+
+This is an experimental alternative to `EMLTree1D` in `eml_sr.py`. Both trees
+have identical parameter shapes and the same outer EML algebra, but they
+differ in how a gate combines its three input candidates `{1, x, child}`:
+
+  * **Option A** (current default, `EMLTree1D`): the gate applies a softmax
+    over three logits, producing a *convex combination* of `{1, x, child}`.
+    The achievable input value is constrained to the simplex spanned by
+    those three sources — every coefficient is non-negative and they sum
+    to 1. This is computationally cheap and snaps cleanly via argmax, but
+    it is strictly weaker than the paper's parameterization.
+
+  * **Option B** (this module, `EMLTree1DLinear`): the gate uses an
+    *unconstrained linear combination*
+
+        input = α·1 + β·x + γ·child
+
+    with `α, β, γ ∈ ℝ` learned via gradient descent. This matches Section
+    4.3 equation (6) of Odrzywolek (2026). Three things change as a result:
+
+    1. Constants outside `[0, max(1, x)]` (notably `e`, `π`, fractional
+       slopes like `0.3`) live in the depth-1 vocabulary directly, since
+       a leaf or gate side can learn an arbitrary real constant.
+    2. **Subtraction of children is finally available**: setting `γ = -1`
+       lets a parent invert its child's contribution. This unlocks
+       depth-2 recoveries such as `eml(ln(x), 1) = x` via the construction
+       `gate_l = 1 - eml(0, x) = 1 - (1 - ln(x)) = ln(x)`, which is
+       *impossible* under Option A because softmax forbids negative
+       coefficients.
+    3. The loss landscape is smooth everywhere — there is no temperature
+       schedule, no entropy penalty, and no simplex corners producing
+       discontinuous gradients. This eliminates a large class of bad
+       local minima (including the `(e − ln(0))` snap that Option A's
+       curriculum mode exhibits on `exp(exp(exp(x)))`).
+
+## Why we built it
+
+After issue #6's Feynman benchmark and issue #11's diagnosis, we observed
+that Option A failed on every nonlinear target outside its tightest
+vocabulary — `ln(x)` snapped to `e`, `exp(x) - 1` snapped to `exp(x)`,
+`exp(exp(exp(x)))` produced `(e − ln(0))`, and all linear targets
+(`y = x`, `0.3·x`, `9.81·x`) bottomed out as constants. Issue #4
+explicitly listed Option A as the "minimal" fix and Option B as the
+"paper's approach", and we picked A in commit `9363cb9` because it was
+sufficient for the test case in #4 (`eml(x, x) = exp(x) - ln(x)` at
+depth 1). We never circled back to validate that Option A could handle
+the rest of the paper's bootstrap chain. This module addresses that gap.
+
+## Snap to symbolic expressions
+
+The tree's expressivity gain comes at a cost: snapping real-valued
+coefficients to a clean symbolic form is harder than argmax. The
+prototype here uses a simple recipe:
+
+    if |α| < SNAP_EPS:                    α := 0
+    elif |α - round(α)| < SNAP_EPS:       α := round(α)   # nearest int
+    elif |α - e| < SNAP_EPS:              α := e
+    elif |α + e| < SNAP_EPS:              α := -e
+
+Anything else stays as a learned real and is printed numerically. This
+catches the integer/`e` cases that arise from EML identities; richer
+constant recognition (`π`, `1/e`, `ln(2)`, etc.) is a follow-up.
+
+The expression simplifier in `eml_sr.py` only handles the Option-A
+vocabulary `{1, x, 0, e}`. We do not extend it here — instead we emit
+expressions in a separate "linear-combination" form that the snap
+function can pretty-print but the simplifier won't recursively reduce.
+That's intentional scope control: the experiment's job is to answer
+"can the architecture fit these targets at all?", not to deliver the
+full symbolic-recovery pipeline. If the answer is yes, simplifier
+extension is a follow-up issue.
+
+## Limitations of this prototype
+
+  * No multi-process worker support (single-threaded only).
+  * No curriculum learning. Random init at fixed depths.
+  * Snap-to-symbolic is best-effort — non-canonical expressions may
+    print as numeric coefficients.
+  * Only tested on the issue #11 failing targets; broader regression
+    coverage lives in `tests/test_eml_sr.py` and pertains to Option A.
+
+## Reference
+
+  Odrzywolek, A. (2026). "All elementary functions from a single operator."
+  arXiv:2603.21852. Section 4.3, equation (6).
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+from typing import Optional
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from eml_sr import DTYPE, REAL, _CLAMP, eml_op  # noqa: F401  (re-exported)
+
+
+# ─── Constants ─────────────────────────────────────────────────
+
+# Snap tolerance for recognizing integer / `e` / 0 coefficients.
+SNAP_EPS = 0.05
+
+# Famous constants the snap step recognizes.
+_NAMED_CONSTANTS: list[tuple[float, str]] = [
+    (0.0, "0"),
+    (1.0, "1"),
+    (-1.0, "-1"),
+    (2.0, "2"),
+    (-2.0, "-2"),
+    (math.e, "e"),
+    (-math.e, "-e"),
+]
+
+
+# ─── Tree ──────────────────────────────────────────────────────
+
+class EMLTree1DLinear(nn.Module):
+    """Option B EML tree with unconstrained linear gate combinations.
+
+    Same shape contract as `EMLTree1D` but with paper-faithful
+    parameterization:
+
+      Leaves: input = α + β·x   (2 reals per leaf)
+      Gates:  input = α + β·x + γ·child  (3 reals per side, 2 sides per node)
+
+    Identical parameter tensor *shapes* to `EMLTree1D`. They are *not*
+    interchangeable — the values are coefficients here, not pre-softmax
+    logits.
+    """
+
+    def __init__(self, depth: int, init_scale: float = 0.1):
+        super().__init__()
+        self.depth = depth
+        self.n_leaves = 2 ** depth
+        self.n_internal = self.n_leaves - 1
+
+        # Leaf coefficients: (n_leaves, 2) — [α (constant), β (x)]
+        # Initialize close to the depth-1 atom `α=1, β=0` (constant 1) so
+        # the tree starts as a stable constant-1 fit and the optimizer
+        # discovers structure from there.
+        leaf_init = torch.randn(self.n_leaves, 2, dtype=REAL) * init_scale
+        leaf_init[:, 0] += 1.0  # bias α toward 1
+        self.leaf_logits = nn.Parameter(leaf_init)
+
+        # Gate coefficients: (n_internal, 2, 3) — [α (constant), β (x), γ (child)]
+        # Bias γ toward 1.0 so the child contribution flows up by default;
+        # this matches Option A's behavior of "child" being the most
+        # informative source after random init.
+        gate_init = torch.randn(self.n_internal, 2, 3, dtype=REAL) * init_scale
+        gate_init[..., 2] += 1.0  # bias γ toward 1
+        self.gate_logits = nn.Parameter(gate_init)
+
+    def forward(self, x, tau: float = 1.0):  # tau accepted for API parity, unused
+        x = x.to(DTYPE)
+        batch = x.shape[0]
+        ones = torch.ones(batch, dtype=DTYPE)
+
+        # Leaf values: α + β·x (no softmax, no temperature)
+        a = self.leaf_logits[:, 0].to(DTYPE)  # (n_leaves,)
+        b = self.leaf_logits[:, 1].to(DTYPE)  # (n_leaves,)
+        # broadcast: (batch, n_leaves)
+        level = a.unsqueeze(0) * ones.unsqueeze(1) + b.unsqueeze(0) * x.unsqueeze(1)
+
+        # Bottom-up: pair children, apply gate linear combos, compute eml
+        node_idx = 0
+        x_b = x.unsqueeze(1)  # (batch, 1)
+        while level.shape[1] > 1:
+            n_pairs = level.shape[1] // 2
+            left = level[:, 0::2]   # (batch, n_pairs), complex
+            right = level[:, 1::2]
+
+            g = self.gate_logits[node_idx:node_idx + n_pairs]  # (n_pairs, 2, 3) real
+            g_c = g.to(DTYPE)
+            # α, β, γ for left and right sides
+            a_l = g_c[:, 0, 0].unsqueeze(0)  # (1, n_pairs)
+            b_l = g_c[:, 0, 1].unsqueeze(0)
+            c_l = g_c[:, 0, 2].unsqueeze(0)
+            a_r = g_c[:, 1, 0].unsqueeze(0)
+            b_r = g_c[:, 1, 1].unsqueeze(0)
+            c_r = g_c[:, 1, 2].unsqueeze(0)
+
+            # Free linear combinations — no clamping of coefficients.
+            left_in = a_l + b_l * x_b + c_l * left
+            right_in = a_r + b_r * x_b + c_r * right
+
+            level = eml_op(left_in, right_in)
+
+            # Same numerical clamp as Option A — exp/ln overflow is
+            # independent of the parameterization.
+            level = torch.complex(
+                torch.nan_to_num(level.real, nan=0.0,
+                                 posinf=_CLAMP, neginf=-_CLAMP).clamp(-_CLAMP, _CLAMP),
+                torch.nan_to_num(level.imag, nan=0.0,
+                                 posinf=_CLAMP, neginf=-_CLAMP).clamp(-_CLAMP, _CLAMP),
+            )
+            node_idx += n_pairs
+
+        return level.squeeze(1), None, None  # API-compatible 3-tuple
+
+    def snap(self) -> "EMLTree1DLinear":
+        """Snap each coefficient to the nearest recognized constant.
+
+        Modifies a deep-copied tree in place; returns it. Coefficients
+        that don't match any named constant are left as-is and printed
+        numerically by `to_expr()`.
+        """
+        tree = copy.deepcopy(self)
+        with torch.no_grad():
+            for tensor in (tree.leaf_logits, tree.gate_logits):
+                flat = tensor.view(-1)
+                for i in range(flat.numel()):
+                    v = float(flat[i].item())
+                    snapped = _snap_scalar(v)
+                    if snapped is not None:
+                        flat[i] = snapped
+        return tree
+
+    def to_expr(self) -> str:
+        """Pretty-print the tree as a linear-combination eml expression.
+
+        This does *not* run through the recursive simplifier in
+        `eml_sr.py`, since that simplifier only knows about Option A's
+        atomic vocabulary. The printed form is therefore pre-simplification:
+        readers can verify structure but the surface syntax is verbose.
+        """
+        leaf_a = self.leaf_logits[:, 0].tolist()
+        leaf_b = self.leaf_logits[:, 1].tolist()
+        gate = self.gate_logits.tolist()
+
+        # Pretty-print each leaf as α + β·x.
+        exprs = [_lin_expr(a, b, "x") for a, b in zip(leaf_a, leaf_b)]
+
+        node_idx = 0
+        while len(exprs) > 1:
+            new_exprs = []
+            for i in range(0, len(exprs), 2):
+                left_child, right_child = exprs[i], exprs[i + 1]
+                gl = gate[node_idx]  # [[αl, βl, γl], [αr, βr, γr]]
+                left_in = _lin_expr3(gl[0][0], gl[0][1], gl[0][2],
+                                     "x", left_child)
+                right_in = _lin_expr3(gl[1][0], gl[1][1], gl[1][2],
+                                      "x", right_child)
+                new_exprs.append(f"eml({left_in}, {right_in})")
+                node_idx += 1
+            exprs = new_exprs
+        return exprs[0]
+
+    def n_params(self) -> int:
+        return self.leaf_logits.numel() + self.gate_logits.numel()
+
+
+# ─── Snap & pretty-print helpers ───────────────────────────────
+
+def _snap_scalar(v: float) -> Optional[float]:
+    """Return the snapped value if it matches a named constant within
+    SNAP_EPS, else None to indicate "leave it as a learned real"."""
+    # Named constants first (covers e, integers in [-2, 2]).
+    for c, _ in _NAMED_CONSTANTS:
+        if abs(v - c) < SNAP_EPS:
+            return c
+    # Nearest integer for larger magnitudes.
+    if abs(v - round(v)) < SNAP_EPS:
+        return float(round(v))
+    return None
+
+
+def _fmt_coef(v: float) -> str:
+    """Pretty-print a coefficient: recognize named constants, else
+    print as a 3-significant-figure float."""
+    for c, name in _NAMED_CONSTANTS:
+        if abs(v - c) < SNAP_EPS:
+            return name
+    if abs(v - round(v)) < SNAP_EPS:
+        return str(int(round(v)))
+    return f"{v:.3g}"
+
+
+def _lin_expr(a: float, b: float, var: str) -> str:
+    """Pretty-print α + β·var with sane elision of zeros and ones."""
+    parts = []
+    a_str = _fmt_coef(a) if abs(a) >= SNAP_EPS else None
+    if a_str is not None and a_str != "0":
+        parts.append(a_str)
+    if abs(b) >= SNAP_EPS:
+        if abs(b - 1.0) < SNAP_EPS:
+            parts.append(var)
+        elif abs(b + 1.0) < SNAP_EPS:
+            parts.append(f"-{var}")
+        else:
+            parts.append(f"{_fmt_coef(b)}*{var}")
+    if not parts:
+        return "0"
+    return " + ".join(parts).replace("+ -", "- ")
+
+
+def _lin_expr3(a: float, b: float, c: float, var: str, child: str) -> str:
+    """Pretty-print α + β·var + γ·child."""
+    parts = []
+    if abs(a) >= SNAP_EPS:
+        parts.append(_fmt_coef(a))
+    if abs(b) >= SNAP_EPS:
+        if abs(b - 1.0) < SNAP_EPS:
+            parts.append(var)
+        elif abs(b + 1.0) < SNAP_EPS:
+            parts.append(f"-{var}")
+        else:
+            parts.append(f"{_fmt_coef(b)}*{var}")
+    if abs(c) >= SNAP_EPS:
+        if abs(c - 1.0) < SNAP_EPS:
+            parts.append(child)
+        elif abs(c + 1.0) < SNAP_EPS:
+            parts.append(f"-({child})")
+        else:
+            parts.append(f"{_fmt_coef(c)}*({child})")
+    if not parts:
+        return "0"
+    return " + ".join(parts).replace("+ -", "- ")
+
+
+# ─── Training ──────────────────────────────────────────────────
+
+def _discreteness_penalty(tensor: torch.Tensor) -> torch.Tensor:
+    """Penalty pushing each coefficient toward the nearest named constant.
+
+    For each value v, returns min over `c ∈ {0, ±1, ±2, ±e}` of `(v - c)²`,
+    summed over all elements. Differentiable (min-of-squares is smooth
+    almost everywhere; the kink at the bisector between two constants
+    is on a measure-zero set and Adam's momentum smooths it out).
+
+    This is the Option-B counterpart to Option A's entropy penalty:
+    instead of pushing softmax probabilities toward one-hot, it pushes
+    free coefficients toward an integer / `e` lattice that we know the
+    snap step recognizes.
+    """
+    constants = torch.tensor(
+        [c for c, _ in _NAMED_CONSTANTS], dtype=tensor.dtype
+    )  # (n_const,)
+    flat = tensor.view(-1, 1)  # (n, 1)
+    diffs = (flat - constants.unsqueeze(0)) ** 2  # (n, n_const)
+    nearest = diffs.min(dim=1).values  # (n,)
+    return nearest.sum()
+
+
+def _train_one_linear(
+    x_data: torch.Tensor,
+    targets: torch.Tensor,
+    depth: int,
+    seed: int,
+    search_iters: int = 2000,
+    snap_iters: int = 1500,
+    lr: float = 0.01,
+    lam_disc_max: float = 0.5,
+    verbose: bool = False,
+) -> dict:
+    """Train one Option-B tree from a single random seed.
+
+    Two phases (analogous to Option A's tau anneal but additive
+    rather than temperature-based):
+
+      1. Search (it < search_iters): MSE only. Free coefficients
+         explore the full real-valued parameter space.
+      2. Snap (it >= search_iters): MSE + λ * discreteness_penalty,
+         where λ ramps quadratically from 0 to `lam_disc_max`. The
+         penalty pulls each coefficient toward the nearest member of
+         {0, ±1, ±2, ±e}, which the snap step recognizes.
+
+    There is no temperature schedule and no entropy penalty — both are
+    softmax-specific. There is also no L1 penalty; sparsity emerges
+    naturally from the discreteness penalty pulling toward 0 when no
+    nonzero constant fits the local landscape.
+    """
+    torch.manual_seed(seed)
+    tree = EMLTree1DLinear(depth)
+    opt = torch.optim.Adam(tree.parameters(), lr=lr)
+
+    best_loss = float("inf")
+    best_state = None
+    nan_restarts = 0
+    total = search_iters + snap_iters
+
+    for it in range(1, total + 1):
+        if nan_restarts > 20:
+            break
+
+        opt.zero_grad()
+        pred, _, _ = tree(x_data)
+        mse = torch.mean((pred - targets).abs() ** 2).real
+
+        if it >= search_iters:
+            t = (it - search_iters) / max(1, snap_iters)
+            lam = lam_disc_max * (t ** 2)
+            disc = (_discreteness_penalty(tree.leaf_logits)
+                    + _discreteness_penalty(tree.gate_logits))
+            loss = mse + lam * disc
+        else:
+            loss = mse
+
+        if not torch.isfinite(loss):
+            nan_restarts += 1
+            if best_state is not None:
+                tree.load_state_dict(best_state)
+                opt = torch.optim.Adam(tree.parameters(), lr=lr)
+            continue
+
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(tree.parameters(), 1.0)
+        opt.step()
+
+        val = float(mse.item())
+        if math.isfinite(val) and val < best_loss:
+            best_loss = val
+            best_state = {k: v.clone() for k, v in tree.state_dict().items()}
+
+        if verbose and it % 500 == 0:
+            print(f"  it={it:5d} mse={val:.3e} best={best_loss:.3e}")
+
+    if best_state is not None:
+        tree.load_state_dict(best_state)
+
+    snapped = tree.snap()
+    with torch.no_grad():
+        pred_snap, _, _ = snapped(x_data)
+        snap_mse = torch.mean((pred_snap - targets).abs() ** 2).real.item()
+
+    return {
+        "tree": tree,
+        "snapped": snapped,
+        "best_mse": best_loss,
+        "snap_mse": snap_mse,
+        "snap_rmse": math.sqrt(max(snap_mse, 0)),
+        "expr": snapped.to_expr(),
+        "nan_restarts": nan_restarts,
+    }
+
+
+def discover_linear(
+    x: np.ndarray,
+    y: np.ndarray,
+    max_depth: int = 4,
+    n_tries: int = 8,
+    verbose: bool = True,
+    success_threshold: float = 1e-10,
+) -> Optional[dict]:
+    """Option-B counterpart of `eml_sr.discover()`.
+
+    Tries depths 1 through `max_depth`, each with `n_tries` independent
+    seeds. Returns the simplest (shallowest) formula that fits within
+    `success_threshold`. API mirrors `discover()` for drop-in use in
+    benchmarks.
+    """
+    x_t = torch.tensor(x, dtype=REAL)
+    y_t = torch.tensor(y, dtype=DTYPE) if y.dtype.kind == "c" \
+        else torch.tensor(y, dtype=DTYPE)
+
+    best_overall = None
+    for depth in range(1, max_depth + 1):
+        if verbose:
+            print(f"\n─── depth {depth} (linear / Option B) ───")
+        best_at_depth = None
+        for seed in range(n_tries):
+            result = _train_one_linear(x_t, y_t, depth, seed)
+            if verbose and (seed < 2 or result["snap_rmse"] < 1e-5):
+                print(f"  seed {seed:2d}: snap_rmse={result['snap_rmse']:.3e} "
+                      f"expr={result['expr'][:60]}")
+            if best_at_depth is None or result["snap_mse"] < best_at_depth["snap_mse"]:
+                best_at_depth = result
+            if result["snap_mse"] < success_threshold:
+                break
+
+        if best_at_depth and best_at_depth["snap_mse"] < success_threshold:
+            return {
+                "expr": best_at_depth["expr"],
+                "depth": depth,
+                "snap_rmse": best_at_depth["snap_rmse"],
+                "snapped_tree": best_at_depth["snapped"],
+                "method": "linear",
+            }
+        if best_overall is None or (best_at_depth
+                                    and best_at_depth["snap_mse"] < best_overall["snap_mse"]):
+            best_overall = best_at_depth
+
+    return {
+        "expr": best_overall["expr"],
+        "depth": best_overall["snapped"].depth,
+        "snap_rmse": best_overall["snap_rmse"],
+        "snapped_tree": best_overall["snapped"],
+        "exact": False,
+        "method": "linear",
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest config for eml-sr tests."""
+import os
+import sys
+
+# Ensure the repo root (where eml_sr.py lives) is importable.
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: marks multi-seed recovery tests that run a full training ladder",
+    )

--- a/tests/test_eml_sr.py
+++ b/tests/test_eml_sr.py
@@ -1,0 +1,454 @@
+"""Comprehensive Python test suite for eml_sr.
+
+Replaces the legacy Mojo stack-machine tests with pytest coverage of the
+PyTorch symbolic regression engine:
+
+    1. Unit tests for the EML operator                       (::TestEmlOp)
+    2. Tree architecture tests                               (::TestTreeArchitecture)
+    3. Known-target recovery tests                           (::TestRecovery)
+    4. Regression tests against numpy / reference values     (::TestRegression)
+    5. Property tests (idempotence, depth monotonicity, ...) (::TestProperties)
+    6. Expression simplifier tests                           (::TestSimplifier)
+
+Multi-seed recovery tests are marked ``@pytest.mark.slow`` so the default run
+stays fast. Run everything with ``pytest -m "not slow or slow"`` or simply
+``pytest``; skip the slow ones with ``pytest -m "not slow"``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+import eml_sr
+from eml_sr import (
+    DTYPE,
+    REAL,
+    EMLTree1D,
+    _simplify,
+    _train_one,
+    discover,
+    eml_op,
+)
+
+
+# ───────────────────────── helpers ──────────────────────────
+
+def _as_complex(x):
+    return torch.tensor(np.asarray(x), dtype=DTYPE)
+
+
+def _as_real(x):
+    return torch.tensor(np.asarray(x), dtype=REAL)
+
+
+def _fast_train(x, y, depth, seed=0, search=250, hard=100):
+    """Tiny training budget for property / regression tests."""
+    x_t = _as_real(x)
+    y_t = _as_complex(y)
+    return _train_one(
+        x_t, y_t, depth=depth, seed=seed,
+        search_iters=search, hard_iters=hard, verbose=False,
+    )
+
+
+# ═══════════════════════ 1. eml_op unit tests ═══════════════════════
+
+class TestEmlOp:
+    """eml_op(x, y) = exp(x) - ln(y) on torch.complex128."""
+
+    def test_known_values(self):
+        # eml(0, 1) = exp(0) - ln(1) = 1 - 0 = 1
+        r = eml_op(_as_complex([0.0]), _as_complex([1.0]))
+        assert torch.allclose(r.real, torch.tensor([1.0], dtype=REAL))
+        assert torch.allclose(r.imag, torch.tensor([0.0], dtype=REAL))
+
+    def test_eml_x_1_is_exp(self):
+        x = _as_real(np.linspace(-2.0, 2.0, 11))
+        r = eml_op(x.to(DTYPE), _as_complex(np.ones(11)))
+        expected = torch.exp(x)
+        assert torch.allclose(r.real, expected, atol=1e-12)
+        assert torch.allclose(r.imag, torch.zeros_like(r.imag), atol=1e-12)
+
+    def test_eml_0_x_is_neg_ln(self):
+        x = _as_real(np.linspace(0.1, 5.0, 10))
+        r = eml_op(_as_complex(np.zeros(10)), x.to(DTYPE))
+        # eml(0, x) = 1 - ln(x)
+        expected = 1.0 - torch.log(x)
+        assert torch.allclose(r.real, expected, atol=1e-12)
+
+    def test_eml_x_e_equals_exp_minus_1(self):
+        e = _as_complex(np.full(5, math.e))
+        x = _as_real(np.linspace(0.0, 2.0, 5))
+        r = eml_op(x.to(DTYPE), e)
+        expected = torch.exp(x) - 1.0
+        assert torch.allclose(r.real, expected, atol=1e-12)
+
+    def test_eml_is_exp_minus_ln(self):
+        # Pure definition check over random points.
+        torch.manual_seed(0)
+        x = torch.randn(20, dtype=REAL)
+        y = torch.rand(20, dtype=REAL) + 0.1  # keep y > 0
+        lhs = eml_op(x.to(DTYPE), y.to(DTYPE))
+        rhs = torch.exp(x) - torch.log(y)
+        assert torch.allclose(lhs.real, rhs, atol=1e-12)
+
+    def test_complex_branch_cut_negative_real(self):
+        # ln of a negative real enters the upper branch: ln(-1) = iπ.
+        r = eml_op(_as_complex([0.0]), _as_complex([-1.0 + 0j]))
+        # eml(0, -1) = 1 - ln(-1) = 1 - iπ
+        assert abs(r[0].real.item() - 1.0) < 1e-12
+        assert abs(r[0].imag.item() + math.pi) < 1e-12
+
+    def test_complex_input(self):
+        # Both inputs complex: eml(i, 1) = exp(i) - 0 = cos(1) + i sin(1)
+        r = eml_op(_as_complex([1j]), _as_complex([1.0 + 0j]))
+        assert abs(r[0].real.item() - math.cos(1.0)) < 1e-12
+        assert abs(r[0].imag.item() - math.sin(1.0)) < 1e-12
+
+    def test_ln_zero_gives_neg_inf(self):
+        r = eml_op(_as_complex([0.0]), _as_complex([0.0]))
+        # ln(0) = -inf → eml = 1 - (-inf) = +inf
+        assert torch.isinf(r.real).item()
+        assert r.real.item() > 0
+
+    def test_inf_inputs_produce_nonfinite(self):
+        r = eml_op(_as_complex([float("inf")]), _as_complex([1.0]))
+        assert not torch.isfinite(r.real).item()
+
+
+# ═══════════════════════ 2. Tree architecture tests ═══════════════════════
+
+class TestTreeArchitecture:
+
+    @pytest.mark.parametrize("depth", [1, 2, 3, 4])
+    def test_leaf_and_internal_counts(self, depth):
+        tree = EMLTree1D(depth)
+        assert tree.n_leaves == 2 ** depth
+        assert tree.n_internal == 2 ** depth - 1
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_parameter_count(self, depth):
+        tree = EMLTree1D(depth)
+        # leaf_logits: n_leaves * 2, gate_logits: n_internal * 2 * 3
+        expected = (2 ** depth) * 2 + (2 ** depth - 1) * 6
+        got = sum(p.numel() for p in tree.parameters())
+        assert got == expected
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_forward_shapes(self, depth):
+        tree = EMLTree1D(depth)
+        x = _as_real(np.linspace(0.5, 2.5, 7))
+        pred, leaf_probs, gate_probs = tree(x, tau=1.0)
+        assert pred.shape == (7,)
+        assert pred.dtype == DTYPE
+        assert leaf_probs.shape == (2 ** depth, 2)
+        assert gate_probs.shape == (2 ** depth - 1, 2, 3)
+
+    def test_forward_finite(self):
+        # Even with extreme input magnitudes, forward must stay finite
+        # (clamp/scrub logic is part of the contract).
+        tree = EMLTree1D(3)
+        x = _as_real(np.linspace(-10.0, 10.0, 25))
+        pred, _, _ = tree(x, tau=1.0)
+        assert torch.isfinite(pred.real).all()
+        assert torch.isfinite(pred.imag).all()
+
+    def test_snap_returns_deep_copy(self):
+        tree = EMLTree1D(2)
+        snapped = tree.snap()
+        assert snapped is not tree
+        # Mutating original shouldn't affect snapped.
+        with torch.no_grad():
+            tree.leaf_logits.add_(100.0)
+        assert not torch.allclose(tree.leaf_logits, snapped.leaf_logits)
+
+    def test_snap_produces_hard_onehots(self):
+        tree = EMLTree1D(3)
+        snapped = tree.snap()
+        # Every softmax row should have max prob ~= 1.0.
+        with torch.no_grad():
+            lp = torch.softmax(snapped.leaf_logits, dim=1)
+            gp = torch.softmax(snapped.gate_logits, dim=-1)
+        assert (lp.max(dim=1).values > 0.999).all()
+        assert (gp.max(dim=-1).values > 0.999).all()
+        assert snapped.n_uncertain() == 0
+
+    def test_snap_is_idempotent(self):
+        torch.manual_seed(7)
+        tree = EMLTree1D(3)
+        snapped1 = tree.snap()
+        snapped2 = snapped1.snap()
+        assert torch.allclose(snapped1.leaf_logits, snapped2.leaf_logits)
+        assert torch.allclose(snapped1.gate_logits, snapped2.gate_logits)
+
+    def test_to_expr_parseable(self):
+        torch.manual_seed(0)
+        tree = EMLTree1D(2).snap()
+        expr = tree.to_expr()
+        assert isinstance(expr, str) and len(expr) > 0
+        # Simplification must not crash on its own output.
+        assert _simplify(expr) == expr or _simplify(_simplify(expr)) == _simplify(expr)
+
+    def test_n_uncertain_bounds(self):
+        tree = EMLTree1D(3)
+        # Random init: at most n_leaves + 2*n_internal parameters can be uncertain.
+        max_nu = tree.n_leaves + 2 * tree.n_internal
+        assert 0 <= tree.n_uncertain() <= max_nu
+
+
+# ═══════════════════════ 3. Known-target recovery ═══════════════════════
+
+class TestRecovery:
+    """The key tests: can training recover known targets?
+
+    Fast recovery tests (depth 1) run by default. The ≥8-seed ladder tests
+    are gated behind ``-m slow`` so a default ``pytest`` stays snappy.
+    """
+
+    def test_snap_of_manual_exp_tree(self):
+        """A depth-1 tree hand-snapped to eml(x, 1) = exp(x) should fit exactly."""
+        tree = EMLTree1D(1)
+        with torch.no_grad():
+            k = 50.0
+            # leaf 0 → x (index 1), leaf 1 → 1 (index 0)
+            tree.leaf_logits.copy_(torch.tensor([[-k, k], [k, -k]], dtype=REAL))
+            # gate: route both sides to child (index 2)
+            g = torch.full((1, 2, 3), -k, dtype=REAL)
+            g[0, :, 2] = k
+            tree.gate_logits.copy_(g)
+        x = _as_real(np.linspace(0.5, 2.5, 15))
+        pred, _, _ = tree(x, tau=0.01)
+        expected = torch.exp(x)
+        assert torch.allclose(pred.real, expected, atol=1e-9)
+        assert tree.to_expr() == "exp(x)"
+
+    def test_snap_of_constant_e(self):
+        """Default init's biased toward constant 1 — and snaps to 'e'."""
+        torch.manual_seed(0)
+        tree = EMLTree1D(1).snap()
+        assert tree.to_expr() == "e"
+        x = _as_real(np.linspace(0.5, 2.5, 10))
+        pred, _, _ = tree(x, tau=0.01)
+        assert torch.allclose(pred.real, torch.full((10,), math.e, dtype=REAL), atol=1e-9)
+
+    def test_recover_exp_depth1_fast(self):
+        """exp(x) at depth 1 — should succeed on seed 0 alone."""
+        x = np.linspace(0.5, 2.5, 20)
+        y = np.exp(x)
+        out = _fast_train(x, y, depth=1, seed=0, search=700, hard=250)
+        assert out["snap_rmse"] < 1e-8
+        assert out["expr"] == "exp(x)"
+
+    def test_recover_constant_e_depth1_fast(self):
+        """Constant `e` is depth 1 — routing picks child = eml(1,1) = exp(1) - ln(1) = e."""
+        x = np.linspace(0.5, 2.5, 20)
+        y = np.full_like(x, np.e)
+        out = _fast_train(x, y, depth=1, seed=0, search=700, hard=250)
+        assert out["snap_rmse"] < 1e-8
+        assert out["expr"] == "e"
+
+    @pytest.mark.slow
+    def test_recover_exp_depth1_ladder(self):
+        """≤4 seeds at depth 1 must recover exp(x)."""
+        x = np.linspace(0.5, 2.5, 25)
+        y = np.exp(x)
+        r = discover(x, y, max_depth=1, n_tries=4, verbose=False)
+        assert r is not None
+        assert r["snap_rmse"] < 1e-8
+        assert r["expr"] == "exp(x)"
+
+    @pytest.mark.slow
+    def test_recover_constant_e(self):
+        """Constant e at depth 1 — 100% success within a few seeds."""
+        x = np.linspace(0.5, 2.5, 25)
+        y = np.full_like(x, np.e)
+        r = discover(x, y, max_depth=1, n_tries=4, verbose=False)
+        assert r is not None
+        assert r["snap_rmse"] < 1e-8
+        assert r["expr"] == "e"
+
+    @pytest.mark.slow
+    def test_recover_ln_depth3(self):
+        """ln(x) lives at depth 3: ln(x) = -eml(0, x) + 1 via several nested forms.
+
+        Requires 8 seeds for ≥75% aggregate success — we just need ≥1 hit.
+        """
+        x = np.linspace(0.5, 5.0, 30)
+        y = np.log(x)
+        r = discover(x, y, max_depth=3, n_tries=8, verbose=False)
+        assert r is not None
+        # ln is hard from random init; accept either exact or near-exact fit.
+        assert r["snap_rmse"] < 1e-4
+
+    @pytest.mark.slow
+    def test_recover_exp_minus_ln(self):
+        """exp(x) - ln(x) = eml(x, x) at depth 1 — exercises the gate routing."""
+        x = np.linspace(0.5, 3.0, 25)
+        y = np.exp(x) - np.log(x)
+        r = discover(x, y, max_depth=2, n_tries=8, verbose=False)
+        assert r is not None
+        # Accept any formula within tight RMSE — exact form may differ.
+        assert r["snap_rmse"] < 1e-6
+
+
+# ═══════════════════════ 4. Regression tests ═══════════════════════
+
+class TestRegression:
+    """Numerical regression: snapped trees match numpy reference values."""
+
+    def test_exp_snap_matches_numpy(self):
+        tree = EMLTree1D(1)
+        # Hand-snap to exp(x).
+        with torch.no_grad():
+            k = 50.0
+            tree.leaf_logits.copy_(torch.tensor([[-k, k], [k, -k]], dtype=REAL))
+            g = torch.full((1, 2, 3), -k, dtype=REAL)
+            g[0, :, 2] = k
+            tree.gate_logits.copy_(g)
+        x_np = np.linspace(-1.0, 2.0, 15)
+        pred, _, _ = tree(_as_real(x_np), tau=0.01)
+        np.testing.assert_allclose(pred.real.detach().numpy(), np.exp(x_np), atol=1e-10)
+
+    def test_training_does_not_leak_nan(self):
+        """Training on a sane target must not end with a NaN MSE."""
+        out = _fast_train(
+            np.linspace(0.5, 2.0, 15), np.exp(np.linspace(0.5, 2.0, 15)),
+            depth=1, seed=0, search=200, hard=100,
+        )
+        assert np.isfinite(out["best_mse"])
+        assert np.isfinite(out["snap_mse"])
+
+    def test_training_with_harsh_target_recovers_gracefully(self):
+        """Even if the target is out of reach, training must still return finite stats."""
+        # sin(x) is NOT expressible as eml(x,1) alone at depth 1 — fit will be poor
+        # but must not crash and must not return NaN.
+        x = np.linspace(-1.0, 1.0, 15)
+        y = np.sin(x)
+        out = _fast_train(x, y, depth=1, seed=0, search=200, hard=100)
+        assert np.isfinite(out["best_mse"])
+        assert np.isfinite(out["snap_mse"])
+        assert out["nan_restarts"] <= 20
+
+
+# ═══════════════════════ 5. Property tests ═══════════════════════
+
+class TestProperties:
+
+    def test_snap_is_idempotent_on_trained_tree(self):
+        out = _fast_train(
+            np.linspace(0.5, 2.0, 15), np.exp(np.linspace(0.5, 2.0, 15)),
+            depth=1, seed=0, search=200, hard=100,
+        )
+        snapped1 = out["snapped"]
+        snapped2 = snapped1.snap()
+        assert torch.allclose(snapped1.leaf_logits, snapped2.leaf_logits)
+        assert torch.allclose(snapped1.gate_logits, snapped2.gate_logits)
+        # Same forward output.
+        x = _as_real(np.linspace(0.5, 2.0, 15))
+        p1, _, _ = snapped1(x, tau=0.01)
+        p2, _, _ = snapped2(x, tau=0.01)
+        assert torch.allclose(p1.real, p2.real, atol=1e-12)
+
+    @pytest.mark.parametrize("tau", [0.01, 0.1, 1.0, 2.0])
+    def test_snapped_tree_is_tau_invariant(self, tau):
+        """Once snapped, output should be (nearly) independent of tau."""
+        torch.manual_seed(1)
+        tree = EMLTree1D(2).snap()
+        x = _as_real(np.linspace(0.5, 2.0, 10))
+        base, _, _ = tree(x, tau=0.01)
+        other, _, _ = tree(x, tau=tau)
+        # At hard snap levels the softmax is ~one-hot regardless of tau.
+        assert torch.allclose(base.real, other.real, atol=1e-8)
+        assert torch.allclose(base.imag, other.imag, atol=1e-8)
+
+    def test_deeper_trees_can_express_shallower(self):
+        """A depth-2 tree, when appropriately snapped, can realize exp(x) —
+        just like a depth-1 tree. Verify by matching outputs."""
+        # Depth 1: exp(x) = eml(x, 1).
+        shallow = EMLTree1D(1)
+        with torch.no_grad():
+            k = 50.0
+            shallow.leaf_logits.copy_(torch.tensor([[-k, k], [k, -k]], dtype=REAL))
+            g = torch.full((1, 2, 3), -k, dtype=REAL)
+            g[0, :, 2] = k
+            shallow.gate_logits.copy_(g)
+
+        # Depth 2: a subtree passing x through, then eml(x, 1) at the root.
+        # The lower-level gate routes both sides to the LEAF (value x, 1)
+        # but a simpler approach is to bypass the lower subtree via gate
+        # choices [x, 1] at the root, which is exactly eml(x, 1) = exp(x).
+        deep = EMLTree1D(2)
+        with torch.no_grad():
+            k = 50.0
+            # Leaves don't matter — root gate bypasses them.
+            deep.leaf_logits.copy_(
+                torch.tensor([[k, -k], [k, -k], [k, -k], [k, -k]], dtype=REAL))
+            # Internal nodes: root is index 2 in bottom-up order; first 2 are
+            # the lower gates. Set all gates to something, then the root to
+            # route side 0 → x (index 1), side 1 → 1 (index 0).
+            g = torch.full((3, 2, 3), -k, dtype=REAL)
+            g[0, :, 0] = k  # lower left: both sides → 1
+            g[1, :, 0] = k  # lower right: both sides → 1
+            g[2, 0, 1] = k  # root left → x
+            g[2, 1, 0] = k  # root right → 1
+            deep.gate_logits.copy_(g)
+
+        x = _as_real(np.linspace(0.5, 2.0, 10))
+        ps, _, _ = shallow(x, tau=0.01)
+        pd, _, _ = deep(x, tau=0.01)
+        assert torch.allclose(ps.real, pd.real, atol=1e-9)
+
+    def test_forward_determinism(self):
+        """Given a fixed state, repeated forward calls produce identical outputs."""
+        torch.manual_seed(42)
+        tree = EMLTree1D(2)
+        x = _as_real(np.linspace(0.5, 2.0, 10))
+        a, _, _ = tree(x, tau=1.0)
+        b, _, _ = tree(x, tau=1.0)
+        assert torch.allclose(a.real, b.real)
+        assert torch.allclose(a.imag, b.imag)
+
+
+# ═══════════════════════ 6. Expression simplifier ═══════════════════════
+
+class TestSimplifier:
+
+    def test_eml_x_1_is_exp_x(self):
+        assert _simplify("eml(x, 1)") == "exp(x)"
+
+    def test_eml_1_1_is_e(self):
+        # eml(1, 1) = exp(1) - ln(1) = e - 0 = e
+        assert _simplify("eml(1, 1)") == "e"
+
+    def test_eml_0_1_is_1(self):
+        # eml(0, 1) = exp(0) - ln(1) = 1 - 0 = 1
+        assert _simplify("eml(0, 1)") == "1"
+
+    def test_eml_x_x_is_exp_minus_ln(self):
+        # eml(x, x) = exp(x) - ln(x); simplifier shouldn't collapse this (non-trivial).
+        got = _simplify("eml(x, x)")
+        assert "exp(x)" in got and "ln(x)" in got
+
+    def test_atom_passthrough(self):
+        assert _simplify("x") == "x"
+        assert _simplify("1") == "1"
+
+    def test_malformed_expression_passthrough(self):
+        # Simplifier has a defensive try/except — malformed input returns as-is.
+        bad = "eml(x"
+        assert _simplify(bad) == bad
+
+    def test_nested_eml_simplifies(self):
+        # eml(eml(x, 1), 1) = eml(exp(x), 1) = exp(exp(x)) - ln(1) = exp(exp(x))
+        got = _simplify("eml(eml(x, 1), 1)")
+        assert got == "exp(exp(x))"
+
+    def test_simplify_is_fixed_point(self):
+        expr = "eml(eml(x, 1), eml(1, 1))"
+        once = _simplify(expr)
+        twice = _simplify(once)
+        assert once == twice

--- a/tests/test_eml_sr_linear.py
+++ b/tests/test_eml_sr_linear.py
@@ -1,0 +1,320 @@
+"""Test suite for eml_sr_linear (Option B) and eml_sr_hybrid.
+
+Covers:
+    1. EMLTree1DLinear architecture (shapes, forward, snap, to_expr)
+    2. Helper functions (_snap_scalar, _discreteness_penalty, etc.)
+    3. Training and iterative snap
+    4. discover_linear API
+    5. discover_hybrid staged fallback
+
+Multi-seed recovery tests are marked ``@pytest.mark.slow``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from eml_sr import DTYPE, REAL, eml_op
+from eml_sr_linear import (
+    EMLTree1DLinear,
+    _discreteness_penalty,
+    _nearest_snap,
+    _snap_scalar,
+    _train_one_linear,
+    discover_linear,
+    iterative_snap,
+)
+from eml_sr_hybrid import discover_hybrid
+
+
+# ───────────────────────── helpers ──────────────────────────
+
+def _as_real(x):
+    return torch.tensor(np.asarray(x), dtype=REAL)
+
+
+def _as_complex(x):
+    return torch.tensor(np.asarray(x), dtype=DTYPE)
+
+
+# ═══════════════════════ 1. Architecture tests ══════════════════════
+
+class TestLinearTreeArchitecture:
+    """Verify EMLTree1DLinear parameter shapes and forward pass."""
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_param_shapes(self, depth):
+        tree = EMLTree1DLinear(depth)
+        n_leaves = 2 ** depth
+        n_internal = n_leaves - 1
+        assert tree.leaf_logits.shape == (n_leaves, 2)
+        assert tree.gate_logits.shape == (n_internal, 2, 3)
+
+    @pytest.mark.parametrize("depth", [1, 2, 3])
+    def test_forward_output_shape(self, depth):
+        tree = EMLTree1DLinear(depth)
+        x = _as_real(np.linspace(0.5, 3.0, 20))
+        out, lp, gp = tree(x)
+        assert out.shape == (20,)
+        assert out.dtype == DTYPE
+        # Option B returns None for leaf_probs and gate_probs
+        assert lp is None
+        assert gp is None
+
+    def test_forward_batch_independence(self):
+        """Each sample computes independently (no cross-batch contamination)."""
+        tree = EMLTree1DLinear(2)
+        x1 = _as_real([1.0, 2.0])
+        x2 = _as_real([1.0, 2.0, 3.0])
+        out1, _, _ = tree(x1)
+        out2, _, _ = tree(x2)
+        # First two outputs should match
+        torch.testing.assert_close(out1, out2[:2])
+
+    def test_snap_is_idempotent(self):
+        tree = EMLTree1DLinear(2)
+        snapped1 = tree.snap()
+        snapped2 = snapped1.snap()
+        torch.testing.assert_close(
+            snapped1.leaf_logits, snapped2.leaf_logits)
+        torch.testing.assert_close(
+            snapped1.gate_logits, snapped2.gate_logits)
+
+    def test_snap_returns_new_tree(self):
+        tree = EMLTree1DLinear(1)
+        snapped = tree.snap()
+        assert snapped is not tree
+        # Modifying snapped should not affect original
+        with torch.no_grad():
+            snapped.leaf_logits[0, 0] = 999.0
+        assert tree.leaf_logits[0, 0].item() != 999.0
+
+    def test_to_expr_returns_string(self):
+        tree = EMLTree1DLinear(1)
+        expr = tree.snap().to_expr()
+        assert isinstance(expr, str)
+        assert len(expr) > 0
+
+    def test_n_params(self):
+        tree = EMLTree1DLinear(2)
+        expected = tree.leaf_logits.numel() + tree.gate_logits.numel()
+        assert tree.n_params() == expected
+
+    def test_hand_crafted_exp(self):
+        """Hand-set coefficients to compute eml(x, 1) = exp(x)."""
+        tree = EMLTree1DLinear(1)
+        with torch.no_grad():
+            # Leaves: left = x (α=0, β=1), right = 1 (α=1, β=0)
+            tree.leaf_logits.copy_(torch.tensor(
+                [[0.0, 1.0], [1.0, 0.0]], dtype=REAL))
+            # Gate: pass children through (α=0, β=0, γ=1 for both sides)
+            tree.gate_logits.copy_(torch.tensor(
+                [[[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]], dtype=REAL))
+        x = _as_real(np.linspace(0.1, 2.0, 20))
+        out, _, _ = tree(x)
+        expected = torch.exp(x.to(DTYPE))
+        torch.testing.assert_close(out, expected, atol=1e-12, rtol=1e-12)
+
+
+# ═══════════════════════ 2. Helper function tests ═══════════════════
+
+class TestSnapHelpers:
+    """Test _snap_scalar and _nearest_snap."""
+
+    def test_snap_zero(self):
+        assert _snap_scalar(0.001) == 0.0
+
+    def test_snap_one(self):
+        assert _snap_scalar(0.98) == 1.0
+
+    def test_snap_neg_one(self):
+        assert _snap_scalar(-1.02) == -1.0
+
+    def test_snap_e(self):
+        assert _snap_scalar(math.e + 0.01) == math.e
+
+    def test_snap_neg_e(self):
+        assert _snap_scalar(-math.e + 0.01) == -math.e
+
+    def test_snap_two(self):
+        assert _snap_scalar(2.03) == 2.0
+
+    def test_no_snap_far(self):
+        """Values far from any named constant return None."""
+        assert _snap_scalar(1.5) is None
+
+    def test_nearest_snap_distance(self):
+        target, dist = _nearest_snap(0.5)
+        # Closest named constant is either 0 or 1, distance 0.5
+        assert dist == pytest.approx(0.5)
+        assert target in (0.0, 1.0)
+
+
+class TestDiscretnessPenalty:
+    """Test _discreteness_penalty."""
+
+    def test_at_integers(self):
+        """Penalty is zero at exact integers."""
+        t = torch.tensor([0.0, 1.0, -1.0, 2.0], dtype=REAL)
+        p = _discreteness_penalty(t)
+        assert float(p.item()) == pytest.approx(0.0, abs=1e-10)
+
+    def test_at_e(self):
+        t = torch.tensor([math.e], dtype=REAL)
+        p = _discreteness_penalty(t)
+        assert float(p.item()) == pytest.approx(0.0, abs=1e-10)
+
+    def test_midpoint_nonzero(self):
+        """Penalty is nonzero between named constants."""
+        t = torch.tensor([0.5], dtype=REAL)
+        p = _discreteness_penalty(t)
+        assert float(p.item()) > 0.01
+
+    def test_gradient_flows(self):
+        t = torch.tensor([0.5], dtype=REAL, requires_grad=True)
+        p = _discreteness_penalty(t)
+        p.backward()
+        assert t.grad is not None
+        assert t.grad.abs().item() > 0
+
+
+# ═══════════════════════ 3. Training tests ══════════════════════════
+
+class TestTrainOneLinear:
+    """Test _train_one_linear returns valid results."""
+
+    def test_returns_expected_keys(self):
+        x = _as_real(np.linspace(0.5, 3.0, 25))
+        y = _as_complex(np.exp(np.linspace(0.5, 3.0, 25)))
+        r = _train_one_linear(x, y, depth=1, seed=0,
+                              search_iters=50, snap_iters=50)
+        assert "tree" in r
+        assert "snapped" in r
+        assert "best_mse" in r
+        assert "snap_mse" in r
+        assert "snap_rmse" in r
+        assert "expr" in r
+        assert "nan_restarts" in r
+
+    def test_training_reduces_loss(self):
+        """After training, MSE should be lower than initial."""
+        x = _as_real(np.linspace(0.5, 3.0, 25))
+        y = _as_complex(np.exp(np.linspace(0.5, 3.0, 25)))
+        r = _train_one_linear(x, y, depth=1, seed=42,
+                              search_iters=200, snap_iters=100)
+        assert r["best_mse"] < 100.0  # should decrease from random init
+
+    def test_snap_rmse_is_sqrt_snap_mse(self):
+        x = _as_real(np.linspace(0.5, 3.0, 25))
+        y = _as_complex(np.exp(np.linspace(0.5, 3.0, 25)))
+        r = _train_one_linear(x, y, depth=1, seed=0,
+                              search_iters=50, snap_iters=50)
+        assert r["snap_rmse"] == pytest.approx(
+            math.sqrt(max(r["snap_mse"], 0)), abs=1e-12)
+
+
+class TestIterativeSnap:
+    """Test iterative_snap preserves or improves fit quality."""
+
+    def test_snap_does_not_destroy_fit(self):
+        """Iterative snap should not increase MSE catastrophically."""
+        x = _as_real(np.linspace(0.5, 3.0, 25))
+        y_np = np.exp(np.linspace(0.5, 3.0, 25))
+        y = _as_complex(y_np)
+        r = _train_one_linear(x, y, depth=1, seed=0,
+                              search_iters=500, snap_iters=200)
+        snapped = iterative_snap(r["tree"], x, y,
+                                 retrain_iters=100, verbose=False)
+        with torch.no_grad():
+            pred, _, _ = snapped(x)
+            snap_mse = float(torch.mean(
+                (pred - y).abs() ** 2).real.item())
+        # Should not be worse than 100× the pre-snap fit
+        assert snap_mse < r["best_mse"] * 200 + 1.0
+
+    def test_returns_tree_instance(self):
+        x = _as_real(np.linspace(0.5, 3.0, 15))
+        y = _as_complex(np.exp(np.linspace(0.5, 3.0, 15)))
+        r = _train_one_linear(x, y, depth=1, seed=0,
+                              search_iters=50, snap_iters=50)
+        snapped = iterative_snap(r["tree"], x, y,
+                                 retrain_iters=50, verbose=False)
+        assert isinstance(snapped, EMLTree1DLinear)
+
+
+# ═══════════════════════ 4. discover_linear tests ═══════════════════
+
+class TestDiscoverLinear:
+    """Test the discover_linear API."""
+
+    def test_returns_dict_with_expected_keys(self):
+        x = np.linspace(0.5, 3.0, 25)
+        y = np.exp(x)
+        r = discover_linear(x, y, max_depth=1, n_tries=2, verbose=False)
+        assert isinstance(r, dict)
+        assert "expr" in r
+        assert "depth" in r
+        assert "snap_rmse" in r
+        assert "method" in r
+        assert r["method"] == "linear"
+
+    @pytest.mark.slow
+    def test_recover_exp(self):
+        """Option B should fit exp(x) reasonably well."""
+        x = np.linspace(0.5, 3.0, 30)
+        y = np.exp(x)
+        r = discover_linear(x, y, max_depth=2, n_tries=4, verbose=False)
+        assert r["snap_rmse"] < 1.0  # may not be machine-precision
+
+    @pytest.mark.slow
+    def test_recover_identity(self):
+        """y = x is a key target Option B should handle (Option A cannot)."""
+        x = np.linspace(0.5, 3.0, 30)
+        y = x.copy()
+        r = discover_linear(x, y, max_depth=3, n_tries=6, verbose=False)
+        # Option B should fit y = x with reasonable RMSE
+        assert r["snap_rmse"] < 0.5
+
+
+# ═══════════════════════ 5. discover_hybrid tests ═══════════════════
+
+class TestDiscoverHybrid:
+    """Test the hybrid A→B fallback dispatcher."""
+
+    @pytest.mark.slow
+    def test_hybrid_on_exp(self):
+        """exp(x) is in Option A's vocabulary — hybrid should use A."""
+        x = np.linspace(0.5, 3.0, 30)
+        y = np.exp(x)
+        r = discover_hybrid(x, y, max_depth=2, n_tries_a=4,
+                            n_tries_b=2, verbose=False)
+        assert r is not None
+        assert r["method"] == "option_a"
+        assert r["snap_rmse"] < 1e-6
+
+    @pytest.mark.slow
+    def test_hybrid_on_identity(self):
+        """y = x needs Option B fallback."""
+        x = np.linspace(0.5, 3.0, 30)
+        y = x.copy()
+        r = discover_hybrid(x, y, max_depth=3, n_tries_a=4,
+                            n_tries_b=4, max_depth_b=3, verbose=False)
+        assert r is not None
+        # Should have fallen back to Option B (or A got lucky, either is fine)
+        assert r["snap_rmse"] < 1.0
+
+    def test_hybrid_returns_expected_keys(self):
+        """Even with minimal budget, returns a dict with required keys."""
+        x = np.linspace(0.5, 3.0, 15)
+        y = np.exp(x)
+        r = discover_hybrid(x, y, max_depth=1, n_tries_a=1,
+                            n_tries_b=1, verbose=False)
+        assert r is not None
+        assert "expr" in r
+        assert "method" in r
+        assert "snap_rmse" in r
+        assert r["method"] in ("option_a", "option_b")

--- a/tests/test_eml_sr_linear.py
+++ b/tests/test_eml_sr_linear.py
@@ -28,7 +28,7 @@ from eml_sr_linear import (
     discover_linear,
     iterative_snap,
 )
-from eml_sr_hybrid import discover_hybrid
+from eml_sr_hybrid import discover_hybrid, warm_start_a_from_b
 
 
 # ───────────────────────── helpers ──────────────────────────
@@ -317,4 +317,72 @@ class TestDiscoverHybrid:
         assert "expr" in r
         assert "method" in r
         assert "snap_rmse" in r
-        assert r["method"] in ("option_a", "option_b")
+        assert r["method"] in ("option_a", "option_b", "warm_start_a")
+
+
+# ═══════════════════════ 6. warm_start_a_from_b tests ═══════════════
+
+class TestWarmStartAFromB:
+    """Test warm-starting Option A from Option B's structure (issue #12)."""
+
+    def test_returns_option_a_tree(self):
+        """Output should be an EMLTree1D with correct depth."""
+        from eml_sr import EMLTree1D
+        b = EMLTree1DLinear(2)
+        a = warm_start_a_from_b(b)
+        assert isinstance(a, EMLTree1D)
+        assert a.depth == 2
+        assert a.n_leaves == 4
+        assert a.n_internal == 3
+
+    def test_preserves_depth(self):
+        for d in [1, 2, 3]:
+            b = EMLTree1DLinear(d)
+            a = warm_start_a_from_b(b)
+            assert a.depth == d
+
+    def test_leaf_logits_biased(self):
+        """Leaf logits should be biased toward the dominant B coefficient."""
+        b = EMLTree1DLinear(1)
+        with torch.no_grad():
+            # Set leaf 0 to favor x (β > α), leaf 1 to favor 1 (α > β)
+            b.leaf_logits.copy_(torch.tensor(
+                [[0.1, 5.0], [3.0, 0.2]], dtype=REAL))
+        a = warm_start_a_from_b(b, bias=4.0)
+        # Leaf 0: x dominant → logit[1] should be positive, logit[0] negative
+        assert a.leaf_logits[0, 1].item() > a.leaf_logits[0, 0].item()
+        # Leaf 1: 1 dominant → logit[0] should be positive, logit[1] negative
+        assert a.leaf_logits[1, 0].item() > a.leaf_logits[1, 1].item()
+
+    def test_gate_logits_biased(self):
+        """Gate logits should be biased toward the dominant B coefficient."""
+        b = EMLTree1DLinear(1)
+        with torch.no_grad():
+            # Gate: left side child-dominant (γ=5), right side x-dominant (β=3)
+            b.gate_logits.copy_(torch.tensor(
+                [[[0.1, 0.2, 5.0], [0.1, 3.0, 0.2]]], dtype=REAL))
+        a = warm_start_a_from_b(b, bias=4.0)
+        # Left side: child (idx 2) dominant
+        assert a.gate_logits[0, 0, 2].item() > a.gate_logits[0, 0, 0].item()
+        assert a.gate_logits[0, 0, 2].item() > a.gate_logits[0, 0, 1].item()
+        # Right side: x (idx 1) dominant
+        assert a.gate_logits[0, 1, 1].item() > a.gate_logits[0, 1, 0].item()
+        assert a.gate_logits[0, 1, 1].item() > a.gate_logits[0, 1, 2].item()
+
+    def test_forward_runs(self):
+        """Warm-started A tree should produce valid forward output."""
+        b = EMLTree1DLinear(2)
+        a = warm_start_a_from_b(b)
+        x = _as_real(np.linspace(0.5, 3.0, 20))
+        out, lp, gp = a(x)
+        assert out.shape == (20,)
+        assert torch.isfinite(out.real).all()
+
+    def test_does_not_modify_b(self):
+        """warm_start_a_from_b should not mutate the input B tree."""
+        b = EMLTree1DLinear(1)
+        leaf_before = b.leaf_logits.clone()
+        gate_before = b.gate_logits.clone()
+        _ = warm_start_a_from_b(b)
+        torch.testing.assert_close(b.leaf_logits, leaf_before)
+        torch.testing.assert_close(b.gate_logits, gate_before)

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -1,0 +1,205 @@
+"""Test multivariate support for EMLTree1D and EMLTree1DLinear (issue #15).
+
+Verifies:
+    1. Construction with n_vars > 1
+    2. Forward pass shape correctness
+    3. Parameter shapes
+    4. Snap and to_expr for multivariate trees
+    5. Backward compatibility: n_vars=1 matches original behavior
+    6. Same for EMLTree1DLinear
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from eml_sr import DTYPE, REAL, EMLTree1D, eml_op
+from eml_sr_linear import EMLTree1DLinear
+
+
+def _as_real(x):
+    return torch.tensor(np.asarray(x), dtype=REAL)
+
+
+# ═══════════════════════ Option A multivariate ══════════════════════
+
+class TestEMLTree1DMultivariate:
+    """EMLTree1D with n_vars > 1."""
+
+    @pytest.mark.parametrize("n_vars", [2, 3, 5])
+    def test_construction(self, n_vars):
+        tree = EMLTree1D(depth=2, n_vars=n_vars)
+        assert tree.n_vars == n_vars
+        assert tree.leaf_logits.shape == (4, n_vars + 1)
+        assert tree.gate_logits.shape == (3, 2, n_vars + 2)
+
+    @pytest.mark.parametrize("n_vars", [2, 3])
+    def test_forward_shape(self, n_vars):
+        tree = EMLTree1D(depth=2, n_vars=n_vars)
+        X = torch.randn(20, n_vars, dtype=REAL)
+        out, lp, gp = tree(X)
+        assert out.shape == (20,)
+        assert out.dtype == DTYPE
+        assert lp.shape == (4, n_vars + 1)
+        assert gp.shape == (3, 2, n_vars + 2)
+
+    def test_forward_2d_batch(self):
+        """2D input (batch, n_vars) works."""
+        tree = EMLTree1D(depth=1, n_vars=2)
+        X = torch.randn(10, 2, dtype=REAL)
+        out, _, _ = tree(X)
+        assert out.shape == (10,)
+
+    def test_snap_multivariate(self):
+        tree = EMLTree1D(depth=1, n_vars=3)
+        snapped = tree.snap()
+        assert snapped.leaf_logits.shape == tree.leaf_logits.shape
+        assert snapped.gate_logits.shape == tree.gate_logits.shape
+        # Snap is idempotent
+        snapped2 = snapped.snap()
+        torch.testing.assert_close(
+            snapped.leaf_logits, snapped2.leaf_logits)
+        torch.testing.assert_close(
+            snapped.gate_logits, snapped2.gate_logits)
+
+    def test_to_expr_multivariate_vars(self):
+        """With n_vars > 1, expression should use x1, x2, ... names."""
+        tree = EMLTree1D(depth=1, n_vars=2)
+        snapped = tree.snap()
+        expr = snapped.to_expr()
+        assert isinstance(expr, str)
+        # Should contain x1 or x2 (or 1, depending on snap)
+        # At minimum it should be a valid string
+        assert len(expr) > 0
+
+    def test_to_expr_univariate_uses_x(self):
+        """With n_vars=1, expression should use 'x' not 'x1'."""
+        tree = EMLTree1D(depth=1, n_vars=1)
+        snapped = tree.snap()
+        expr = snapped.to_expr()
+        # Should use "x" not "x1"
+        assert "x1" not in expr or "x" in expr
+
+    def test_hand_crafted_eml_x1_x2(self):
+        """Hand-snap a 2-var depth-1 tree to compute eml(x1, x2)."""
+        tree = EMLTree1D(depth=1, n_vars=2, init_scale=0.0)
+        k = 50.0
+        with torch.no_grad():
+            # Leaf 0 → x1 (index 1), Leaf 1 → x2 (index 2)
+            leaf = torch.full((2, 3), -k, dtype=REAL)
+            leaf[0, 1] = k  # leaf 0 = x1
+            leaf[1, 2] = k  # leaf 1 = x2
+            tree.leaf_logits.copy_(leaf)
+            # Gate: pass children through (index 3 = child, which is n_vars+1=3)
+            gate = torch.full((1, 2, 4), -k, dtype=REAL)
+            gate[0, 0, 3] = k  # left side → child
+            gate[0, 1, 3] = k  # right side → child
+            tree.gate_logits.copy_(gate)
+
+        x1 = torch.tensor([0.5, 1.0, 2.0], dtype=REAL)
+        x2 = torch.tensor([1.0, 2.0, 0.5], dtype=REAL)
+        X = torch.stack([x1, x2], dim=1)
+        out, _, _ = tree(X, tau=0.01)
+        expected = eml_op(x1.to(DTYPE), x2.to(DTYPE))
+        torch.testing.assert_close(out, expected, atol=1e-10, rtol=1e-10)
+
+    def test_backward_compat_1d_input(self):
+        """1D tensor input still works with n_vars=1 (backward compat)."""
+        tree = EMLTree1D(depth=2, n_vars=1)
+        x = torch.randn(15, dtype=REAL)
+        out, lp, gp = tree(x)
+        assert out.shape == (15,)
+
+    def test_n_uncertain_multivariate(self):
+        tree = EMLTree1D(depth=1, n_vars=3)
+        n = tree.n_uncertain()
+        assert isinstance(n, int)
+        assert n >= 0
+
+
+# ═══════════════════════ Option B multivariate ══════════════════════
+
+class TestEMLTree1DLinearMultivariate:
+    """EMLTree1DLinear with n_vars > 1."""
+
+    @pytest.mark.parametrize("n_vars", [2, 3, 5])
+    def test_construction(self, n_vars):
+        tree = EMLTree1DLinear(depth=2, n_vars=n_vars)
+        assert tree.n_vars == n_vars
+        assert tree.leaf_logits.shape == (4, n_vars + 1)
+        assert tree.gate_logits.shape == (3, 2, n_vars + 2)
+
+    @pytest.mark.parametrize("n_vars", [2, 3])
+    def test_forward_shape(self, n_vars):
+        tree = EMLTree1DLinear(depth=2, n_vars=n_vars)
+        X = torch.randn(20, n_vars, dtype=REAL)
+        out, lp, gp = tree(X)
+        assert out.shape == (20,)
+        assert out.dtype == DTYPE
+        assert lp is None
+        assert gp is None
+
+    def test_snap_multivariate(self):
+        tree = EMLTree1DLinear(depth=1, n_vars=3)
+        snapped = tree.snap()
+        assert snapped.leaf_logits.shape == tree.leaf_logits.shape
+        assert snapped.gate_logits.shape == tree.gate_logits.shape
+
+    def test_to_expr_multivariate(self):
+        tree = EMLTree1DLinear(depth=1, n_vars=2)
+        snapped = tree.snap()
+        expr = snapped.to_expr()
+        assert isinstance(expr, str)
+        assert len(expr) > 0
+
+    def test_to_expr_univariate_backward_compat(self):
+        """n_vars=1 should use 'x' not 'x1'."""
+        tree = EMLTree1DLinear(depth=1, n_vars=1)
+        expr = tree.snap().to_expr()
+        assert "x1" not in expr
+
+    def test_hand_crafted_eml_x1_x2(self):
+        """Hand-set coefficients for eml(x1, x2) = exp(x1) - ln(x2)."""
+        tree = EMLTree1DLinear(depth=1, n_vars=2, init_scale=0.0)
+        with torch.no_grad():
+            # Leaf 0: 0 + 1*x1 + 0*x2 = x1
+            # Leaf 1: 0 + 0*x1 + 1*x2 = x2
+            tree.leaf_logits.copy_(torch.tensor(
+                [[0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], dtype=REAL))
+            # Gate: α=0, β1=0, β2=0, γ=1 for both sides → pass children
+            tree.gate_logits.copy_(torch.tensor(
+                [[[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, 1.0]]], dtype=REAL))
+
+        x1 = torch.tensor([0.5, 1.0, 2.0], dtype=REAL)
+        x2 = torch.tensor([1.0, 2.0, 0.5], dtype=REAL)
+        X = torch.stack([x1, x2], dim=1)
+        out, _, _ = tree(X)
+        expected = eml_op(x1.to(DTYPE), x2.to(DTYPE))
+        torch.testing.assert_close(out, expected, atol=1e-10, rtol=1e-10)
+
+    def test_backward_compat_1d_input(self):
+        """1D tensor input still works with n_vars=1."""
+        tree = EMLTree1DLinear(depth=2, n_vars=1)
+        x = torch.randn(15, dtype=REAL)
+        out, _, _ = tree(x)
+        assert out.shape == (15,)
+
+    def test_n_params_multivariate(self):
+        tree = EMLTree1DLinear(depth=2, n_vars=3)
+        # leaves: 4 * (3+1) = 16, gates: 3 * 2 * (3+2) = 30
+        assert tree.n_params() == 16 + 30
+
+
+# ═══════════════════════ Cross-tree consistency ═════════════════════
+
+class TestMultivariateCrossConsistency:
+    """Verify Option A and B have matching shapes for same n_vars."""
+
+    @pytest.mark.parametrize("n_vars", [1, 2, 3])
+    def test_matching_shapes(self, n_vars):
+        a = EMLTree1D(depth=2, n_vars=n_vars)
+        b = EMLTree1DLinear(depth=2, n_vars=n_vars)
+        assert a.leaf_logits.shape == b.leaf_logits.shape
+        assert a.gate_logits.shape == b.gate_logits.shape


### PR DESCRIPTION
## Summary

- **Merges `option-b-linear-coeffs`**: Option B (paper-faithful linear coefficients), hybrid A→B dispatcher, iterative snap, Feynman benchmark retune, and Python test suite
- **Issue #12**: Warm-start Option A from Option B's learned structure — B explores, A commits via tau-anneal. Integrated as Stage 1.5 in `discover_hybrid`
- **Issue #15**: Generalize `EMLTree1D` and `EMLTree1DLinear` forward pass to n input variables (`n_vars` parameter). Leaf logits become `(n_leaves, n_vars+1)`, gate logits become `(n_internal, 2, n_vars+2)`. Full backward compatibility at `n_vars=1`
- **Issue #7**: 110 tests across three test files covering Option A, Option B, hybrid, warm-start, and multivariate

Closes #7, closes #12, closes #15. Also addresses #4 and #11 (diagnosis documented, benchmarks retuned).

## Test plan

- [x] 110 fast tests pass (`pytest tests/ -m "not slow"`)
- [x] All 47 original Option A tests pass unchanged (backward compat)
- [x] Hand-crafted `eml(x1, x2)` verified for both Option A and B multivariate trees
- [x] Warm-start logit biasing verified: leaf and gate dominant-coefficient transfer
- [ ] Run slow recovery tests (`pytest tests/ -m slow`) to validate end-to-end discovery
- [ ] Verify Feynman benchmark still runs (`python -m benchmarks.feynman`)

https://claude.ai/code/session_018L5yFrVorFmUMTHqKF97Tp