### PR TITLE
Issue #16: generalize public API signatures for 2D input

### DIFF
--- a/eml_sr.py
+++ b/eml_sr.py
@@ -433,15 +433,24 @@ def _train_one(
     tau_hard: float = 0.01,
     verbose: bool = False,
     init_tree: Optional[nn.Module] = None,
+    n_vars: Optional[int] = None,
 ) -> dict:
     """Train one EML tree from a single random seed.
 
+    ``x_data`` is either 1D ``(batch,)`` or 2D ``(batch, n_vars)``. The
+    ``EMLTree1D`` is constructed with the matching ``n_vars`` so leaf/gate
+    logits have the right width. If ``n_vars`` is passed explicitly it
+    overrides shape inference (useful when callers have already committed
+    to a dimensionality).
+
     If ``init_tree`` is provided, it is used instead of creating a fresh
-    ``EMLTree1D(depth)`` from the random seed. The seed still sets the
-    torch RNG for reproducibility of the training loop itself.
+    ``EMLTree1D(depth, n_vars=...)`` from the random seed. The seed still
+    sets the torch RNG for reproducibility of the training loop itself.
     """
+    if n_vars is None:
+        n_vars = x_data.shape[1] if x_data.dim() == 2 else 1
     torch.manual_seed(seed)
-    tree = init_tree if init_tree is not None else EMLTree1D(depth)
+    tree = init_tree if init_tree is not None else EMLTree1D(depth, n_vars=n_vars)
     opt = torch.optim.Adam(tree.parameters(), lr=lr)
 
     best_loss = float("inf")
@@ -511,7 +520,7 @@ def _train_one(
 
 
 def discover(
-    x: np.ndarray,
+    X: np.ndarray,
     y: np.ndarray,
     max_depth: int = 4,
     n_tries: int = 16,
@@ -519,13 +528,15 @@ def discover(
     success_threshold: float = 1e-10,
     n_workers: int = 1,
 ) -> Optional[dict]:
-    """Discover a formula relating x → y.
+    """Discover a formula relating X → y.
 
     Tries depths 2 through max_depth, multiple seeds per depth.
     Returns the simplest (shallowest) formula that fits within threshold.
 
     Args:
-        x: input values (1D numpy array)
+        X: input values. Either 1D ``(n_samples,)`` for the univariate
+            case or 2D ``(n_samples, n_vars)`` for multivariate. 1D input
+            is auto-promoted to ``(n_samples, 1)`` for backward compat.
         y: output values (1D numpy array)
         max_depth: maximum tree depth to try (default 4)
         n_tries: random seeds per depth (default 16)
@@ -537,11 +548,22 @@ def discover(
             to wait for its slowest seed before moving to the next depth.
 
     Returns:
-        dict with keys: expr, depth, snap_rmse, snapped_tree
-        or None if no formula found
+        dict with keys: expr, depth, snap_rmse, snapped_tree, n_uncertain,
+        n_vars — or None if no formula found. ``n_vars`` reports the input
+        dimensionality the tree was trained on.
     """
+    # 2D-input shim: accept (n,) or (n, n_vars). The tree forward handles
+    # both, but `EMLTree1D` must be constructed with matching n_vars so
+    # leaf/gate logits have the right width. (Issue #16.)
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    elif X.ndim != 2:
+        raise ValueError(f"X must be 1D or 2D, got shape {X.shape}")
+    n_vars = X.shape[1]
+
     # Prepare data
-    x_t = torch.tensor(x, dtype=REAL)
+    x_t = torch.tensor(X, dtype=REAL)
     y_t = torch.tensor(y, dtype=DTYPE)
 
     best_overall = None
@@ -570,6 +592,7 @@ def discover(
             search_iters=s_iters,
             hard_iters=h_iters,
             verbose=False,
+            n_vars=n_vars,
         )
         for seed, result in _run_seeds(x_t, y_t, depth, n_tries,
                                        train_kwargs, n_workers):
@@ -601,6 +624,7 @@ def discover(
                 "snap_rmse": best_at_depth["snap_rmse"],
                 "snapped_tree": best_at_depth["snapped"],
                 "n_uncertain": best_at_depth["n_uncertain"],
+                "n_vars": n_vars,
             }
 
         if best_overall is None or (best_at_depth and best_at_depth["snap_mse"] < best_overall["snap_mse"]):
@@ -616,6 +640,7 @@ def discover(
         "snap_rmse": best_overall["snap_rmse"],
         "snapped_tree": best_overall["snapped"],
         "n_uncertain": best_overall["n_uncertain"],
+        "n_vars": n_vars,
         "exact": False,
     }
 

--- a/eml_sr_hybrid.py
+++ b/eml_sr_hybrid.py
@@ -91,7 +91,7 @@ def warm_start_a_from_b(
 
 
 def discover_hybrid(
-    x: np.ndarray,
+    X: np.ndarray,
     y: np.ndarray,
     max_depth: int = 4,
     n_tries_a: int = 8,
@@ -100,11 +100,13 @@ def discover_hybrid(
     fallback_threshold: float = 1e-6,
     verbose: bool = True,
 ) -> Optional[dict]:
-    """Discover a formula relating x → y, using Option A first with
+    """Discover a formula relating X → y, using Option A first with
     Option B as a fallback.
 
     Args:
-        x: input values (1D numpy array)
+        X: input values. Either 1D ``(n_samples,)`` or 2D
+            ``(n_samples, n_vars)``. 1D is auto-promoted for backward
+            compat (issue #16).
         y: output values (1D numpy array)
         max_depth: maximum tree depth for Option A (default 4)
         n_tries_a: random seeds per depth for Option A (default 8)
@@ -120,16 +122,25 @@ def discover_hybrid(
             depth: tree depth used
             snap_rmse: RMSE of the snapped tree
             snapped_tree: callable nn.Module
-            method: 'option_a' or 'option_b'
+            n_vars: input dimensionality the tree was trained on
+            method: 'option_a', 'warm_start_a', or 'option_b'
             fit_rmse: (Option B only) pre-snap RMSE showing the
                       architecture's true fitting power
     """
+    # 2D-input shim (issue #16).
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    elif X.ndim != 2:
+        raise ValueError(f"X must be 1D or 2D, got shape {X.shape}")
+    n_vars = X.shape[1]
+
     # ── Stage 1: Option A ──────────────────────────────────────
     if verbose:
         print("═══ Stage 1: Option A (softmax / clean symbolic) ═══")
 
     result_a = discover(
-        x, y,
+        X, y,
         max_depth=max_depth,
         n_tries=n_tries_a,
         verbose=verbose,
@@ -150,7 +161,7 @@ def discover_hybrid(
         print(f"  Above threshold {fallback_threshold:.0e}, "
               f"trying warm-start from Option B.")
 
-    x_t = torch.tensor(x, dtype=REAL)
+    x_t = torch.tensor(X, dtype=REAL)
     y_t = torch.tensor(y, dtype=DTYPE)
 
     # ── Stage 1.5: Warm-start A from B (issue #12) ────────────
@@ -166,12 +177,14 @@ def discover_hybrid(
         for seed in range(n_tries_b):
             b_result = _train_one_linear(
                 x_t, y_t, depth=depth, seed=seed,
-                search_iters=1500, snap_iters=0, lam_disc_max=0.0)
+                search_iters=1500, snap_iters=0, lam_disc_max=0.0,
+                n_vars=n_vars)
 
             # Convert B's structure to A's logits and train A.
             a_init = warm_start_a_from_b(b_result["tree"])
             a_ws = _train_one(x_t, y_t, depth=depth, seed=seed,
-                              init_tree=a_init, verbose=False)
+                              init_tree=a_init, verbose=False,
+                              n_vars=n_vars)
 
             if verbose and a_ws["snap_rmse"] < 1e-3:
                 print(f"  d={depth} s={seed}: "
@@ -197,6 +210,7 @@ def discover_hybrid(
             "depth": best_warm["depth"],
             "snap_rmse": ws_rmse,
             "snapped_tree": best_warm["snapped"],
+            "n_vars": n_vars,
             "method": "warm_start_a",
         }
 
@@ -213,6 +227,7 @@ def discover_hybrid(
             "snap_rmse": ws_rmse,
             "snapped_tree": best_warm["snapped"],
             "n_uncertain": best_warm.get("n_uncertain", 0),
+            "n_vars": n_vars,
         }
 
     # ── Stage 2: Option B (train + iterative snap) ─────────────
@@ -225,7 +240,7 @@ def discover_hybrid(
         for seed in range(n_tries_b):
             r = _train_one_linear(x_t, y_t, depth=depth, seed=seed,
                                   search_iters=3000, snap_iters=10,
-                                  lam_disc_max=0.0)
+                                  lam_disc_max=0.0, n_vars=n_vars)
             r["depth"] = depth
             if best_b is None or r["best_mse"] < best_b["best_mse"]:
                 best_b = r
@@ -277,6 +292,7 @@ def discover_hybrid(
         "depth": best_b["depth"],
         "snap_rmse": b_rmse,
         "snapped_tree": snapped_tree,
+        "n_vars": n_vars,
         "method": "option_b",
         "fit_rmse": best_b["best_mse"] ** 0.5,
     }

--- a/eml_sr_linear.py
+++ b/eml_sr_linear.py
@@ -486,8 +486,14 @@ def _train_one_linear(
     lr: float = 0.01,
     lam_disc_max: float = 0.5,
     verbose: bool = False,
+    n_vars: Optional[int] = None,
 ) -> dict:
     """Train one Option-B tree from a single random seed.
+
+    ``x_data`` is either 1D ``(batch,)`` or 2D ``(batch, n_vars)``. The
+    ``EMLTree1DLinear`` is constructed with matching ``n_vars`` so leaf
+    and gate coefficient tensors have the right width. If ``n_vars`` is
+    passed explicitly it overrides shape inference.
 
     Two phases (analogous to Option A's tau anneal but additive
     rather than temperature-based):
@@ -504,8 +510,10 @@ def _train_one_linear(
     naturally from the discreteness penalty pulling toward 0 when no
     nonzero constant fits the local landscape.
     """
+    if n_vars is None:
+        n_vars = x_data.shape[1] if x_data.dim() == 2 else 1
     torch.manual_seed(seed)
-    tree = EMLTree1DLinear(depth)
+    tree = EMLTree1DLinear(depth, n_vars=n_vars)
     opt = torch.optim.Adam(tree.parameters(), lr=lr)
 
     best_loss = float("inf")
@@ -763,7 +771,7 @@ def _retrain_free(
 
 
 def discover_linear(
-    x: np.ndarray,
+    X: np.ndarray,
     y: np.ndarray,
     max_depth: int = 4,
     n_tries: int = 8,
@@ -776,8 +784,22 @@ def discover_linear(
     seeds. Returns the simplest (shallowest) formula that fits within
     `success_threshold`. API mirrors `discover()` for drop-in use in
     benchmarks.
+
+    Args:
+        X: input values. Either 1D ``(n_samples,)`` or 2D
+            ``(n_samples, n_vars)``. 1D is auto-promoted for backward
+            compat (issue #16).
+        y: output values (1D numpy array)
     """
-    x_t = torch.tensor(x, dtype=REAL)
+    # 2D-input shim (issue #16).
+    X = np.asarray(X)
+    if X.ndim == 1:
+        X = X.reshape(-1, 1)
+    elif X.ndim != 2:
+        raise ValueError(f"X must be 1D or 2D, got shape {X.shape}")
+    n_vars = X.shape[1]
+
+    x_t = torch.tensor(X, dtype=REAL)
     y_t = torch.tensor(y, dtype=DTYPE) if y.dtype.kind == "c" \
         else torch.tensor(y, dtype=DTYPE)
 
@@ -787,7 +809,7 @@ def discover_linear(
             print(f"\n─── depth {depth} (linear / Option B) ───")
         best_at_depth = None
         for seed in range(n_tries):
-            result = _train_one_linear(x_t, y_t, depth, seed)
+            result = _train_one_linear(x_t, y_t, depth, seed, n_vars=n_vars)
             if verbose and (seed < 2 or result["snap_rmse"] < 1e-5):
                 print(f"  seed {seed:2d}: snap_rmse={result['snap_rmse']:.3e} "
                       f"expr={result['expr'][:60]}")
@@ -802,6 +824,7 @@ def discover_linear(
                 "depth": depth,
                 "snap_rmse": best_at_depth["snap_rmse"],
                 "snapped_tree": best_at_depth["snapped"],
+                "n_vars": n_vars,
                 "method": "linear",
             }
         if best_overall is None or (best_at_depth
@@ -813,6 +836,7 @@ def discover_linear(
         "depth": best_overall["snapped"].depth,
         "snap_rmse": best_overall["snap_rmse"],
         "snapped_tree": best_overall["snapped"],
+        "n_vars": n_vars,
         "exact": False,
         "method": "linear",
     }

--- a/tests/test_api_2d.py
+++ b/tests/test_api_2d.py
@@ -1,0 +1,160 @@
+"""Test 2D-input public API (issue #16).
+
+Verifies the public discover / discover_linear / discover_hybrid API
+accepts both 1D ``(n_samples,)`` and 2D ``(n_samples, n_vars)`` inputs,
+and that all return dicts carry ``n_vars``.
+
+The tree-level multivariate support (EMLTree1D / EMLTree1DLinear with
+n_vars>1) is tested in test_multivariate.py; this file is scoped to
+the public-API surface.
+
+Acceptance criteria from issue #16:
+    - discover(x_1d, y) still works (backward compat)
+    - discover(X_2d, y) works when X has 2+ columns
+    - Same for discover_linear, discover_hybrid
+    - result["n_vars"] is present in all return dicts
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eml_sr import discover
+from eml_sr_linear import discover_linear
+from eml_sr_hybrid import discover_hybrid
+
+
+# Keep budgets small — these tests are about API shape, not
+# discovery fidelity. Full multivariate discovery quality is
+# gated on #18 (curriculum) and #19 (sklearn wrapper), not #16.
+_QUICK = dict(max_depth=2, n_tries=2, verbose=False)
+
+
+# ─── Backward compat: 1D input still works ─────────────────────
+
+class TestDiscover1DBackwardCompat:
+    """discover() / discover_linear() / discover_hybrid() accept 1D x."""
+
+    def test_discover_1d(self):
+        x = np.linspace(0.5, 3.0, 20)
+        y = np.exp(x)
+        r = discover(x, y, **_QUICK)
+        assert r is not None
+        assert r["n_vars"] == 1
+
+    def test_discover_linear_1d(self):
+        x = np.linspace(0.5, 3.0, 20)
+        y = np.exp(x)
+        r = discover_linear(x, y, max_depth=2, n_tries=2, verbose=False)
+        assert r is not None
+        assert r["n_vars"] == 1
+
+    def test_discover_hybrid_1d(self):
+        x = np.linspace(0.5, 3.0, 20)
+        y = np.exp(x)
+        r = discover_hybrid(
+            x, y,
+            max_depth=2, n_tries_a=2, n_tries_b=2, max_depth_b=2,
+            verbose=False,
+        )
+        assert r is not None
+        assert r["n_vars"] == 1
+
+
+# ─── 2D input: new capability ──────────────────────────────────
+
+class TestDiscover2D:
+    """discover() accepts X of shape (n_samples, n_vars)."""
+
+    @pytest.mark.parametrize("n_vars", [2, 3])
+    def test_discover_2d_runs(self, n_vars):
+        rng = np.random.default_rng(0)
+        X = rng.uniform(0.5, 2.0, (20, n_vars))
+        y = np.exp(X[:, 0])  # only first var matters; shape is what's tested
+        r = discover(X, y, **_QUICK)
+        assert r is not None
+        assert r["n_vars"] == n_vars
+
+    @pytest.mark.parametrize("n_vars", [2, 3])
+    def test_discover_linear_2d_runs(self, n_vars):
+        rng = np.random.default_rng(0)
+        X = rng.uniform(0.5, 2.0, (20, n_vars))
+        y = np.exp(X[:, 0])
+        r = discover_linear(X, y, max_depth=2, n_tries=2, verbose=False)
+        assert r is not None
+        assert r["n_vars"] == n_vars
+
+    def test_discover_hybrid_2d_runs(self):
+        rng = np.random.default_rng(0)
+        X = rng.uniform(0.5, 2.0, (20, 2))
+        y = np.exp(X[:, 0])
+        r = discover_hybrid(
+            X, y,
+            max_depth=2, n_tries_a=2, n_tries_b=2, max_depth_b=2,
+            verbose=False,
+        )
+        assert r is not None
+        assert r["n_vars"] == 2
+
+
+# ─── Return-dict shape: n_vars always present ──────────────────
+
+class TestReturnDictNVars:
+    """All success paths and all fallback paths include n_vars."""
+
+    def test_discover_exact_path_has_n_vars(self):
+        # y = exp(x) is recovered at shallow depth, exercising the
+        # "exact formula found" early-return branch.
+        x = np.linspace(0.5, 2.0, 20)
+        y = np.exp(x)
+        r = discover(x, y, max_depth=2, n_tries=4, verbose=False)
+        assert r is not None
+        assert "n_vars" in r
+        assert r["n_vars"] == 1
+
+    def test_discover_fallback_path_has_n_vars(self):
+        # A target that won't recover exactly at this depth budget,
+        # forcing the fallback return branch.
+        rng = np.random.default_rng(42)
+        x = np.linspace(-1.0, 1.0, 20)
+        y = rng.uniform(0, 1, 20)  # noise — won't find exact match
+        r = discover(x, y, max_depth=1, n_tries=2, verbose=False,
+                     success_threshold=1e-20)
+        assert r is not None
+        assert "n_vars" in r
+        assert r["n_vars"] == 1
+        assert r.get("exact") is False
+
+    def test_discover_linear_fallback_has_n_vars(self):
+        rng = np.random.default_rng(42)
+        x = np.linspace(-1.0, 1.0, 20)
+        y = rng.uniform(0, 1, 20)
+        r = discover_linear(x, y, max_depth=1, n_tries=2, verbose=False,
+                            success_threshold=1e-20)
+        assert r is not None
+        assert "n_vars" in r
+
+
+# ─── Validation ────────────────────────────────────────────────
+
+class TestInputValidation:
+    """discover/discover_linear/discover_hybrid reject invalid shapes."""
+
+    def test_discover_rejects_3d(self):
+        X = np.ones((10, 2, 2))
+        y = np.ones(10)
+        with pytest.raises(ValueError, match="1D or 2D"):
+            discover(X, y, **_QUICK)
+
+    def test_discover_linear_rejects_3d(self):
+        X = np.ones((10, 2, 2))
+        y = np.ones(10)
+        with pytest.raises(ValueError, match="1D or 2D"):
+            discover_linear(X, y, max_depth=1, n_tries=1, verbose=False)
+
+    def test_discover_hybrid_rejects_3d(self):
+        X = np.ones((10, 2, 2))
+        y = np.ones(10)
+        with pytest.raises(ValueError, match="1D or 2D"):
+            discover_hybrid(X, y, max_depth=1, n_tries_a=1, n_tries_b=1,
+                            max_depth_b=1, verbose=False)


### PR DESCRIPTION
Direction E [2/6] — closes #16.

## What changed

Threads `n_vars` through the public discovery API so 2D input `(n_samples, n_vars)` actually reaches a tree constructed with the matching dimensionality. Tree-level multivariate support landed in #15, but `discover()`, `_train_one()`, and friends still built `EMLTree1D(depth)` with default `n_vars=1`, so any real 2D call would matmul-fail inside the forward pass.

## Files

- **`eml_sr.py`**
  - `_train_one`: optional `n_vars` param, derived from `x_data` shape when absent, passed to `EMLTree1D(depth, n_vars=n_vars)`.
  - `discover`: rename `x` → `X`; add 2D-input shim (1D auto-promoted to `(n, 1)`); reject 3D+ with clear `ValueError`; thread `n_vars` through `train_kwargs` so `_train_one_worker` picks it up via `**kwargs` for the multiprocessing path; add `n_vars` to both exact-path and fallback return dicts.
- **`eml_sr_linear.py`**: same pattern for `_train_one_linear` and `discover_linear`.
- **`eml_sr_hybrid.py`**: rename `x` → `X`; 2D shim at top; thread `n_vars` into all three stage 1.5 / stage 2 worker calls; add `n_vars` to warm-start return, synthetic `result_a`, and Option-B final return.
- **`tests/test_api_2d.py`**: 14 new tests.

## Acceptance criteria (from #16)

- [x] `discover(x_1d, y)` still works (backward compat) — `TestDiscover1DBackwardCompat`
- [x] `discover(X_2d, y)` works when X has 2+ columns — `TestDiscover2D` parametrized over `n_vars ∈ {2, 3}`
- [x] Same for `discover_linear`, `discover_hybrid`
- [x] `result["n_vars"]` is present in all return dicts — `TestReturnDictNVars` covers both the exact-path early return and the fallback return
- [x] 3D input rejected with clear error — `TestInputValidation`

## Test results

New tests: **14 passed** (295s — mostly training time).

Existing tests unchanged. The `test_normalizer_multivariate.py` failures are **pre-existing from #17** (the `Normalizer` class is missing the `n_vars` attribute and 2D path those tests expect) and are out of scope for this PR — flagging separately.

## Caller-compat note

Renaming `x` → `X` is a signature change, but all in-tree callers (`benchmarks/feynman.py`, `benchmarks/option_ab_compare.py`, `eml_sr_sklearn.py`, `eml_sr._demo`, `eml_sr_hybrid` internal call, CLI entry in `eml_sr.py`) pass the input positionally. No `x=` kwarg callers to update.
