### PR TITLE
Issue #19: update sklearn wrapper for native multivariate

### DIFF
--- a/eml_sr_sklearn.py
+++ b/eml_sr_sklearn.py
@@ -6,17 +6,21 @@ module exposes `EMLRegressor`, a thin sklearn-style estimator that wraps
 `eml_sr.discover` / `discover_curriculum` and stores the snapped torch
 tree for prediction.
 
-Limitation: eml-sr is *univariate* (Direction D from the Odrzywolek paper).
-SRBench problems are typically multivariate. `fit(X, y)` will accept a
-single column, or — when `auto_project=True` — pick the column with the
-highest absolute Spearman correlation with y and treat it as the active
-input. This is enough to put eml-sr on the leaderboard for univariate /
-near-univariate problems and to flag the limitation cleanly for the rest.
+eml-sr natively supports multivariate inputs via the Odrzywolek §4.3
+master formula (PR #15 for the forward pass, #18 for curriculum growing,
+#17 for per-column normalization). `EMLRegressor` passes `X` with any
+number of columns straight through by default.
+
+The legacy univariate-projection behaviour is still available via
+``auto_project=True``: when set, `EMLRegressor` picks the single column
+of `X` with the highest absolute Spearman correlation against `y` and
+discards the rest. This used to be the default; as of #19 it is off by
+default but available for explicit univariate-only runs.
 
 Usage (SRBench-style)::
 
     est = EMLRegressor(max_depth=4, n_tries=16, n_workers=8)
-    est.fit(X, y)
+    est.fit(X, y)                # X can be (n,) or (n, n_vars)
     yhat = est.predict(X_test)
     print(est.model_)            # symbolic expression in normalized coords
     print(est.original_model_)   # with the affine substitution applied
@@ -54,7 +58,7 @@ def _spearman_abs(col: np.ndarray, y: np.ndarray) -> float:
 
 
 class EMLRegressor:
-    """sklearn-style univariate symbolic regressor backed by eml-sr.
+    """sklearn-style symbolic regressor backed by eml-sr.
 
     Parameters
     ----------
@@ -67,12 +71,16 @@ class EMLRegressor:
         leaf-splitting growing tree (better for deep formulas).
     normalize : {"minmax", "standard", "none"}
         Affine pre-scaling. EML overflows easily on raw data; "minmax" is
-        the safest default for arbitrary CSVs.
+        the safest default for arbitrary CSVs. Per-column affines are used
+        for multi-variable `X` (see `Normalizer` and PR #17).
     n_workers : int
         Parallel workers used by `discover` (curriculum is serial).
     auto_project : bool
-        If `X` has more than one column, pick the column with the highest
-        |Spearman| against `y` and use that as the univariate input.
+        Legacy univariate mode. If `True` and `X` has more than one column,
+        pick the column with the highest |Spearman| against `y` and use
+        that single column as the input. Default is `False` — `X` is
+        passed through natively as a multivariate input, using the
+        multivariate forward pass added in #15.
     success_threshold : float
         MSE threshold below which a fit is reported as exact.
     verbose : bool
@@ -86,7 +94,7 @@ class EMLRegressor:
         method: str = "discover",
         normalize: str = "minmax",
         n_workers: int = 1,
-        auto_project: bool = True,
+        auto_project: bool = False,
         success_threshold: float = 1e-10,
         verbose: bool = False,
     ):
@@ -109,27 +117,32 @@ class EMLRegressor:
         if X.shape[0] != y.shape[0]:
             raise ValueError(f"X and y row counts differ: {X.shape[0]} vs {y.shape[0]}")
 
-        # Pick active column (univariate restriction).
-        if X.shape[1] == 1:
-            active = 0
-        elif self.auto_project:
+        # Legacy path: project multi-column X down to a single column via
+        # |Spearman| against y. Off by default; kept for explicit runs.
+        if X.shape[1] > 1 and self.auto_project:
             scores = [_spearman_abs(X[:, j], y) for j in range(X.shape[1])]
             active = int(np.argmax(scores))
             if self.verbose:
-                print(f"EMLRegressor: projecting onto column {active} "
+                print(f"EMLRegressor: auto_project → column {active} "
                       f"(|spearman|={scores[active]:.3f})")
+            X = X[:, active:active + 1]
+            self.active_col_ = active
         else:
-            raise ValueError(
-                f"EMLRegressor is univariate; got X with {X.shape[1]} columns "
-                "and auto_project=False. Set auto_project=True to pick the "
-                "best column automatically, or pass a single column."
-            )
+            # Native multivariate path. active_col_ set to None to signal
+            # "used all columns"; predict() keys off its type to decide
+            # whether to subset.
+            self.active_col_ = None
 
-        x = X[:, active]
-        self.active_col_ = active
-        self.normalizer_ = Normalizer.fit(x, y, mode=self.normalize)
-
-        x_n = self.normalizer_.transform_x(x)
+        self.n_vars_ = X.shape[1]
+        # Fit a normalizer over either (n,) (n_vars=1, preserving the
+        # legacy scalar surface) or (n, n_vars). The #17 Normalizer picks
+        # the right internal representation.
+        if self.n_vars_ == 1:
+            self.normalizer_ = Normalizer.fit(X[:, 0], y, mode=self.normalize)
+            x_n = self.normalizer_.transform_x(X[:, 0])
+        else:
+            self.normalizer_ = Normalizer.fit(X, y, mode=self.normalize)
+            x_n = self.normalizer_.transform_x(X)
         y_n = self.normalizer_.transform_y(y)
 
         if self.method == "curriculum":
@@ -165,9 +178,26 @@ class EMLRegressor:
         X = np.asarray(X, dtype=np.float64)
         if X.ndim == 1:
             X = X.reshape(-1, 1)
-        x = X[:, self.active_col_]
-        x_n = self.normalizer_.transform_x(x)
-        x_t = torch.tensor(x_n, dtype=REAL)
+
+        # Route through the stored normalizer + snapped tree. If fit()
+        # projected down to a single column (auto_project=True), honour
+        # that projection; otherwise pass all columns through.
+        if self.active_col_ is not None:
+            x_n = self.normalizer_.transform_x(X[:, self.active_col_])
+            x_t = torch.tensor(x_n, dtype=REAL)
+        else:
+            if X.shape[1] != self.n_vars_:
+                raise ValueError(
+                    f"predict: X has {X.shape[1]} columns, "
+                    f"fit was on {self.n_vars_}"
+                )
+            if self.n_vars_ == 1:
+                x_n = self.normalizer_.transform_x(X[:, 0])
+                x_t = torch.tensor(x_n, dtype=REAL)
+            else:
+                x_n = self.normalizer_.transform_x(X)
+                x_t = torch.tensor(x_n, dtype=REAL)
+
         with torch.no_grad():
             pred, _, _ = self.snapped_tree_(x_t, tau=0.01)
             yp_n = pred.real.detach().cpu().numpy()
@@ -198,17 +228,45 @@ class EMLRegressor:
     def original_model_(self) -> Optional[str]:
         """Symbolic expression with the normalizer's affine transform stitched in.
 
-        Returns a string like `(formula(0.5*x - 1.0) - 2.3) / 0.7`. Useful
-        for quick reading; not algebraically simplified.
+        For a univariate fit (one active column), returns a string like
+        ``(formula(0.5*x - 1.0) - 2.3) / 0.7``. For a multivariate fit,
+        each ``x_k`` is replaced with its per-column affine
+        ``(a_k*x_k + b_k)``. Not algebraically simplified — useful for
+        quick reading rather than downstream symbolic work.
         """
         if not getattr(self, "is_fitted_", False):
             return None
         import re
         n = self.normalizer_
-        x_sub = f"({n.x_a:.6g} * x + {n.x_b:.6g})"
-        # Word-boundary replace so we hit the standalone identifier `x`
-        # without touching `exp` or future identifiers that contain x.
-        formula = re.sub(r"\bx\b", x_sub, self.expr_)
+
+        # Build per-variable substitution map.
+        #
+        # Univariate fit: the model uses `x`. Substitute `x` with the
+        # scalar affine. (Legacy surface, byte-for-byte.)
+        #
+        # Multivariate fit: the model uses `x1, x2, ...`. Each is
+        # substituted with its own (a_k, b_k). Regex is applied
+        # longest-name-first so `x10` doesn't match `x1` mid-token.
+        subs = {}
+        if self.n_vars_ == 1:
+            # x_a/x_b are scalars in the 1D Normalizer path (see #17).
+            a = float(n.x_a if isinstance(n.x_a, float) else n.x_a[0])
+            b = float(n.x_b if isinstance(n.x_b, float) else n.x_b[0])
+            subs["x"] = f"({a:.6g} * x + {b:.6g})"
+        else:
+            # x_a/x_b are 1D arrays of length n_vars_.
+            for i in range(self.n_vars_):
+                a = float(n.x_a[i])
+                b = float(n.x_b[i])
+                subs[f"x{i+1}"] = f"({a:.6g} * x{i+1} + {b:.6g})"
+
+        formula = self.expr_
+        # Longest-first substitution prevents "x1" from partially matching
+        # "x10" (or "x" from matching "x1"/"exp").
+        for name in sorted(subs, key=len, reverse=True):
+            pattern = r"\b" + re.escape(name) + r"\b"
+            formula = re.sub(pattern, subs[name], formula)
+
         if n.y_a == 1.0 and n.y_b == 0.0:
             return formula
         return f"(({formula}) - {n.y_b:.6g}) / {n.y_a:.6g}"

--- a/tests/test_sklearn_multivariate.py
+++ b/tests/test_sklearn_multivariate.py
@@ -1,0 +1,228 @@
+"""Test EMLRegressor native multivariate support (issue #19).
+
+#19 changes:
+    * `auto_project` default flips to `False`; native multivariate is the
+      new default path.
+    * `fit(X_2d, y)` routes all columns through the multivariate forward
+      pass + per-column Normalizer.
+    * `predict(X_2d)` routes through the snapped multivariate tree.
+    * `model_` is the raw expression string (unchanged shape).
+    * `original_model_` back-substitutes `xi → (a_i * xi + b_i)` for each
+      column.
+    * `n_vars_` records the fit dimensionality.
+    * Legacy `auto_project=True` path preserves the old single-column
+      behaviour.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eml_sr_sklearn import EMLRegressor
+
+
+# ─── Backward compatibility: univariate still works ─────────────────────
+
+class TestUnivariateBackcompat:
+    """1D x and single-column 2D X should behave as before #19."""
+
+    def test_1d_x_fit_predict(self):
+        x = np.linspace(0.2, 2.0, 24)
+        y = np.exp(x)
+        est = EMLRegressor(max_depth=2, n_tries=2, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(x, y)
+        assert est.n_vars_ == 1
+        assert est.active_col_ is None  # native path, no projection
+        yhat = est.predict(x)
+        assert yhat.shape == (24,)
+        # Univariate expr should use 'x' (not 'x1').
+        assert "x1" not in est.expr_
+        assert "x" in est.expr_ or "1" == est.expr_
+
+    def test_single_column_2d_x(self):
+        """X shape (n, 1) is also univariate; same result as (n,)."""
+        x = np.linspace(0.2, 2.0, 24)
+        y = np.exp(x)
+        est = EMLRegressor(max_depth=2, n_tries=2, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(x.reshape(-1, 1), y)
+        assert est.n_vars_ == 1
+        yhat = est.predict(x.reshape(-1, 1))
+        assert yhat.shape == (24,)
+
+
+# ─── Native multivariate (default path) ─────────────────────────────────
+
+class TestNativeMultivariate:
+    """auto_project=False (the new default) — all columns used."""
+
+    def test_default_is_native(self):
+        est = EMLRegressor()
+        assert est.auto_project is False
+
+    def test_multicol_fit_uses_all_columns(self):
+        rng = np.random.default_rng(0)
+        X = rng.uniform(0.3, 1.5, size=(32, 3))
+        y = X[:, 1]  # y depends on x2 only; depth-0 atom should nail it.
+        est = EMLRegressor(max_depth=1, n_tries=2, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(X, y)
+        assert est.n_vars_ == 3
+        assert est.active_col_ is None  # not projected down
+
+    def test_depth0_x2_recovery(self):
+        """Native path: curriculum finds y = x2 at depth 0."""
+        rng = np.random.default_rng(1)
+        X = rng.uniform(0.3, 1.5, size=(32, 2))
+        y = X[:, 1]
+        est = EMLRegressor(max_depth=1, n_tries=1, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(X, y)
+        assert est.n_vars_ == 2
+        assert est.exact_ is True
+        # Expression should reference x2.
+        assert "x2" in est.expr_
+        # Prediction should match y within normalizer round-trip.
+        yhat = est.predict(X)
+        np.testing.assert_allclose(yhat, y, atol=1e-8)
+
+    def test_predict_shape(self):
+        rng = np.random.default_rng(2)
+        X = rng.uniform(0.3, 1.5, size=(20, 2))
+        y = X[:, 0] + 0.5 * X[:, 1]
+        est = EMLRegressor(max_depth=1, n_tries=1, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(X, y)
+        yhat = est.predict(X)
+        assert yhat.shape == (20,)
+        # score() returns a float.
+        assert isinstance(est.score(X, y), float)
+
+    def test_predict_rejects_wrong_width(self):
+        rng = np.random.default_rng(3)
+        X = rng.uniform(0.3, 1.5, size=(16, 3))
+        y = X[:, 0]
+        est = EMLRegressor(max_depth=1, n_tries=1, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(X, y)
+        wrong = rng.uniform(0.3, 1.5, size=(10, 2))
+        with pytest.raises(ValueError, match="columns"):
+            est.predict(wrong)
+
+    def test_model_has_multivar_expr(self):
+        rng = np.random.default_rng(4)
+        X = rng.uniform(0.3, 1.5, size=(24, 2))
+        y = X[:, 1]
+        est = EMLRegressor(max_depth=1, n_tries=1, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(X, y)
+        assert "x2" in est.model_
+
+
+# ─── Legacy auto_project=True path ─────────────────────────────────────
+
+class TestAutoProjectLegacy:
+    """auto_project=True should reproduce the pre-#19 single-column behaviour."""
+
+    def test_auto_project_picks_best_column(self):
+        rng = np.random.default_rng(5)
+        x1 = rng.uniform(0.3, 1.5, 40)
+        x2 = rng.uniform(0.3, 1.5, 40)
+        X = np.column_stack([x1, x2])
+        # y correlates strongly with x2, nothing with x1.
+        y = np.exp(x2)
+        est = EMLRegressor(max_depth=2, n_tries=2, method="curriculum",
+                           normalize="none", auto_project=True, verbose=False)
+        est.fit(X, y)
+        assert est.n_vars_ == 1
+        assert est.active_col_ == 1  # picked x2
+        # Expression should use 'x' (univariate).
+        assert "x1" not in est.expr_
+        assert "x2" not in est.expr_
+
+    def test_auto_project_predict_subsets(self):
+        """predict() honours the projection stored at fit time."""
+        rng = np.random.default_rng(6)
+        X = np.column_stack([rng.uniform(0.5, 2.0, 30),
+                             rng.uniform(0.5, 2.0, 30)])
+        y = np.exp(X[:, 1])
+        est = EMLRegressor(max_depth=1, n_tries=2, method="curriculum",
+                           normalize="none", auto_project=True, verbose=False)
+        est.fit(X, y)
+        yhat = est.predict(X)
+        assert yhat.shape == (30,)
+
+
+# ─── original_model_ per-column affine back-substitution ────────────────
+
+class TestOriginalModel:
+    """original_model_ replaces each xi with its per-column affine."""
+
+    def test_univariate_original_model_uses_x(self):
+        x = np.linspace(0.5, 2.0, 24)
+        y = np.exp(x)
+        est = EMLRegressor(max_depth=1, n_tries=2, method="curriculum",
+                           normalize="minmax", verbose=False)
+        est.fit(x, y)
+        s = est.original_model_
+        assert s is not None
+        # Should contain a scalar affine for x: "(a * x + b)" pattern.
+        assert " * x " in s or "* x +" in s
+
+    def test_multivariate_original_model_per_column(self):
+        """Each xi gets its own (a_i * xi + b_i) substitution."""
+        rng = np.random.default_rng(7)
+        X = rng.uniform(0.3, 1.5, size=(32, 2))
+        y = X[:, 1]
+        est = EMLRegressor(max_depth=1, n_tries=1, method="curriculum",
+                           normalize="minmax", verbose=False)
+        est.fit(X, y)
+        s = est.original_model_
+        assert s is not None
+        # The discovered expr is literally 'x2' (depth-0 atom). After
+        # substitution, original_model_ should embed (a2 * x2 + b2) then
+        # apply the inverse y-scale around that.
+        assert "* x2" in s
+        # x1 may or may not appear depending on the formula — here the
+        # formula uses only x2, so x1 shouldn't appear in the substitution.
+        # But we only guarantee: every xi that appeared in expr_ was
+        # substituted.
+        for i in range(1, est.n_vars_ + 1):
+            name = f"x{i}"
+            if name in est.expr_:
+                assert f"* {name}" in s, f"{name} not substituted in {s!r}"
+
+    def test_longest_first_substitution(self):
+        """x1 substitution must not partially match x10 or similar."""
+        # Fit on 10 columns to ensure x10 appears.
+        rng = np.random.default_rng(8)
+        X = rng.uniform(0.3, 1.5, size=(40, 10))
+        y = X[:, 9]  # x10
+        est = EMLRegressor(max_depth=1, n_tries=1, method="curriculum",
+                           normalize="none", verbose=False)
+        est.fit(X, y)
+        # Expression should contain x10. After substitution, there must
+        # not be an orphan 'x1' remaining unsubstituted inside the x10
+        # substitution (i.e. no bare 'x1' left outside a '* x1 +' pattern).
+        assert "x10" in est.expr_
+        s = est.original_model_
+        assert "x10" in s
+        # Sanity: the substitution for x10 should appear.
+        assert "* x10" in s
+
+
+# ─── get_params / set_params ────────────────────────────────────────────
+
+class TestParams:
+    def test_get_params_has_auto_project(self):
+        est = EMLRegressor()
+        p = est.get_params()
+        assert "auto_project" in p
+        assert p["auto_project"] is False  # new default
+
+    def test_set_params_auto_project(self):
+        est = EMLRegressor()
+        est.set_params(auto_project=True)
+        assert est.auto_project is True


### PR DESCRIPTION
Implements Direction E [5/6] from #13. Closes #19.

**Depends on:** #16 (public API 2D — merged), #17 (Normalizer vectorized — merged), #18 (curriculum multivariate — PR #27).

**Stacked on:** `claude/implement-eml-18-curriculum-mv` — base will become `main` after #27 merges.

## What changes

`EMLRegressor` now passes multi-column `X` through the multivariate forward pass by default.

### API surface

| before #19 | after #19 |
|---|---|
| `auto_project=True` by default; multi-col `X` silently projected to single column | `auto_project=False` by default; multi-col `X` fitted natively |
| No `n_vars_` attribute | `n_vars_` records fit dimensionality |
| `active_col_` always an int | `active_col_` is `None` in native path, `int` under legacy `auto_project=True` |
| `original_model_` only substituted `x` (scalar) | `original_model_` substitutes `x_k → (a_k * x_k + b_k)` per column, longest-first so `x1` doesn't partially match `x10` |

### Paths

- **Native (default):** `fit(X, y)` → vectorized Normalizer → `discover` / `discover_curriculum` with full 2D X → snapped tree stored with its `n_vars`.
- **Legacy:** `auto_project=True` preserves pre-#19 behaviour. Picks column with highest `|spearman|` against `y`, then fits univariate. `predict` subsets `X` by `active_col_`.

## Acceptance criteria

- [x] `EMLRegressor(auto_project=False).fit(X_2d, y)` uses all columns
- [x] `EMLRegressor(auto_project=True).fit(X_2d, y)` picks single best column (legacy behavior preserved)
- [x] `predict(X_2d)` returns correct shape
- [x] `score(X_2d, y)` returns R²
- [x] `model_` shows multi-variable expression when n_vars > 1

## Tests

`tests/test_sklearn_multivariate.py` — **15/15 passing**:

- **Backcompat:** 1D x and (n, 1) X both work as before.
- **Native path:** default is native; multi-column fit uses all columns; depth-0 recovery `y = x2` exact; predict shape; wrong-width `predict` raises; `model_` references `x_k` identifiers.
- **Legacy `auto_project=True`:** picks best column via Spearman; `predict` subsets.
- **`original_model_`:** scalar affine for univariate; per-column for multivariate; longest-first substitution works at n_vars=10 (no `x1`/`x10` collision).
- **`get_params` / `set_params`:** `auto_project` present and settable; default is False.
