### PR TITLE
Issue #20: multivariate tests, benchmark, and validation

### DIFF
--- a/benchmarks/feynman.py
+++ b/benchmarks/feynman.py
@@ -72,13 +72,80 @@ from eml_sr import REAL, discover, discover_curriculum, Normalizer  # noqa: E402
 
 @dataclass
 class FeynmanProblem:
+    """A Feynman benchmark target — univariate or multivariate.
+
+    Univariate (legacy, backward-compatible):
+
+        FeynmanProblem(
+            "eml.exp", "exp", "exp(x)", lambda x: np.exp(x),
+            x_range=(0.5, 2.5),
+        )
+
+    Multivariate (issue #20):
+
+        FeynmanProblem(
+            "II.2.42", "power-2var", "exp(x1) - ln(x2)",
+            lambda X: np.exp(X[:, 0]) - np.log(X[:, 1]),
+            n_vars=2, x_ranges=[(0.5, 2.5), (0.5, 3.0)],
+        )
+
+    Rules:
+      - ``n_vars == 1`` ⇒ ``fn`` receives a 1D ``x`` and returns a 1D ``y``.
+      - ``n_vars >= 2`` ⇒ ``fn`` receives a 2D ``X`` of shape
+        ``(n_samples, n_vars)`` and returns a 1D ``y``.
+      - Exactly one of ``x_range`` (univariate) or ``x_ranges``
+        (multivariate, list of per-column ``(lo, hi)`` tuples) must be
+        supplied. If ``x_range`` is given and ``x_ranges`` is not,
+        ``x_ranges`` is synthesized to ``[x_range]`` for uniformity; the
+        sampler still emits 1D when ``n_vars == 1``.
+    """
+
     feynman_id: str
     name: str           # short readable label
-    formula: str        # human-readable formula in terms of x
+    formula: str        # human-readable formula in terms of x / x1, x2, ...
     fn: Callable[[np.ndarray], np.ndarray]
-    x_range: tuple      # (lo, hi)
+    x_range: Optional[tuple] = None          # legacy univariate (lo, hi)
     n_samples: int = 100
     notes: str = ""
+    n_vars: int = 1
+    x_ranges: Optional[list] = None          # list of (lo, hi) per column
+
+    def __post_init__(self):
+        # Synthesize the full x_ranges list for uniform downstream access,
+        # while preserving the univariate sampler's 1D output.
+        if self.x_ranges is None:
+            if self.x_range is None:
+                raise ValueError(
+                    f"{self.feynman_id}: must supply x_range or x_ranges"
+                )
+            self.x_ranges = [self.x_range]
+        if len(self.x_ranges) != self.n_vars:
+            raise ValueError(
+                f"{self.feynman_id}: n_vars={self.n_vars} does not match "
+                f"len(x_ranges)={len(self.x_ranges)}"
+            )
+
+
+def _sample_X(prob: FeynmanProblem) -> np.ndarray:
+    """Generate inputs for a Feynman problem.
+
+    Univariate (``n_vars == 1``): returns a 1D ``linspace`` over the
+    single range — byte-identical to the legacy sampler so existing
+    univariate benchmarks reproduce exactly.
+
+    Multivariate (``n_vars >= 2``): returns a 2D array of shape
+    ``(n_samples, n_vars)`` where each column is an independent
+    uniform sample over its declared range. A fixed RNG seed keeps
+    runs reproducible across invocations.
+    """
+    if prob.n_vars == 1:
+        lo, hi = prob.x_ranges[0]
+        return np.linspace(lo, hi, prob.n_samples)
+    # Multivariate: per-column independent uniform samples.
+    # Seed by feynman_id so each problem has a stable sample set.
+    rng = np.random.default_rng(abs(hash(prob.feynman_id)) % (2**32))
+    cols = [rng.uniform(lo, hi, prob.n_samples) for (lo, hi) in prob.x_ranges]
+    return np.stack(cols, axis=1)
 
 
 # Helpers used by several problems ------------------------------------
@@ -171,6 +238,43 @@ PROBLEMS: list[FeynmanProblem] = [
         x_range=(0.5, 10.0),
         notes="gravitational PE, m=1 kg",
     ),
+
+    # ── Multivariate targets (issue #20) ────────────────────────
+    # The bivariate slice of eml-sr. These exist to exercise the
+    # 2D code paths end-to-end; the depth-1 atom below is the only
+    # one guaranteed to recover in the default n_tries budget. The
+    # harder ones (addition, division) push against the "search
+    # frontier" that Direction E set out to characterise.
+    FeynmanProblem(
+        "mv.eml", "bivariate-eml", "exp(x1) - ln(x2)",
+        lambda X: np.exp(X[:, 0]) - np.log(X[:, 1]),
+        n_vars=2, x_ranges=[(0.5, 2.5), (0.5, 3.0)],
+        notes="depth-1 bivariate atom — eml(x1, x2) directly",
+    ),
+    FeynmanProblem(
+        "mv.expsum", "exp-of-sum", "exp(x1 + x2) = exp(x1)*exp(x2)",
+        lambda X: np.exp(X[:, 0]) * np.exp(X[:, 1]),
+        n_vars=2, x_ranges=[(0.0, 1.0), (0.0, 1.0)],
+        notes="needs addition; depth 2+. Option A no; Option B via linear leaves",
+    ),
+    FeynmanProblem(
+        "II.6.15a", "coulomb-2var", "x1 / x2^2",
+        lambda X: X[:, 0] / (X[:, 1] ** 2),
+        n_vars=2, x_ranges=[(0.5, 3.0), (0.5, 3.0)],
+        notes="needs division; deep in EML chain — stress test",
+    ),
+    FeynmanProblem(
+        "mv.ln-ratio", "ln-ratio", "ln(x1) - ln(x2)",
+        lambda X: np.log(X[:, 0]) - np.log(X[:, 1]),
+        n_vars=2, x_ranges=[(0.5, 3.0), (0.5, 3.0)],
+        notes="two logs — representable at depth 2 via eml(0,x2)-eml(0,x1)-like",
+    ),
+    FeynmanProblem(
+        "mv.sum-exp", "sum-of-exps", "exp(x1) + exp(x2)",
+        lambda X: np.exp(X[:, 0]) + np.exp(X[:, 1]),
+        n_vars=2, x_ranges=[(0.0, 1.5), (0.0, 1.5)],
+        notes="sum of two exps — not a depth-1 atom; explores depth/search frontier",
+    ),
 ]
 
 
@@ -180,22 +284,22 @@ PROBLEMS: list[FeynmanProblem] = [
 def _run_one(prob: FeynmanProblem, *, max_depth: int, n_tries: int,
              method: str, normalize: str, n_workers: int,
              threshold: float) -> dict:
-    x = np.linspace(prob.x_range[0], prob.x_range[1], prob.n_samples)
-    y = prob.fn(x)
+    X = _sample_X(prob)
+    y = prob.fn(X)
 
-    norm = Normalizer.fit(x, y, mode=normalize)
-    x_n = norm.transform_x(x)
+    norm = Normalizer.fit(X, y, mode=normalize)
+    X_n = norm.transform_x(X)
     y_n = norm.transform_y(y)
 
     t0 = time.time()
     if method == "curriculum":
         result = discover_curriculum(
-            x_n, y_n, max_depth=max_depth, n_tries=n_tries,
+            X_n, y_n, max_depth=max_depth, n_tries=n_tries,
             verbose=False, success_threshold=threshold,
         )
     else:
         result = discover(
-            x_n, y_n, max_depth=max_depth, n_tries=n_tries,
+            X_n, y_n, max_depth=max_depth, n_tries=n_tries,
             verbose=False, success_threshold=threshold,
             n_workers=n_workers,
         )
@@ -215,7 +319,7 @@ def _run_one(prob: FeynmanProblem, *, max_depth: int, n_tries: int,
     rmse_orig = float("inf")
     if snapped is not None:
         with torch.no_grad():
-            pred_n, _, _ = snapped(torch.tensor(x_n, dtype=REAL), tau=0.01)
+            pred_n, _, _ = snapped(torch.tensor(X_n, dtype=REAL), tau=0.01)
             pred_n_np = pred_n.real.detach().numpy()
             pred_orig = norm.inverse_y(pred_n_np)
             rmse_orig = float(np.sqrt(np.mean((pred_orig - y) ** 2)))

--- a/benchmarks/validate_multivariate.py
+++ b/benchmarks/validate_multivariate.py
@@ -1,0 +1,183 @@
+"""Multivariate validation for issue #20 (Direction E [6/6]).
+
+Runs ``discover_hybrid(X, y)`` on three multivariate targets spanning
+the expected difficulty spectrum:
+
+    1. ``eml(x1, x2) = exp(x1) - ln(x2)`` — the depth-1 bivariate atom;
+       must recover at depth 1 with machine precision.
+    2. ``exp(x1) * exp(x2) = exp(x1 + x2)`` — needs an addition inside
+       an exp; depth 2+ territory. Option A cannot represent x1+x2
+       natively (no addition atom), so this probes the hybrid's
+       Option-B fallback path.
+    3. ``x1 / x2^2`` — a genuinely hard bivariate Feynman-style target
+       (Coulomb-like). Establishes the depth/search frontier for
+       n_vars=2: where the search budget starts to bite.
+
+Each run reports: method dispatch (option_a / warm_start_a / option_b),
+discovered depth, original-space RMSE, and wall clock.
+
+Univariate baselines for calibration:
+
+    discover_hybrid on exp(x) at depth 1 → option_a, <1e-10, ~a few seconds.
+    discover_hybrid on ln(x) at depth 3  → option_a, <1e-10, ~tens of s.
+
+Usage::
+
+    python -m benchmarks.validate_multivariate              # default budget
+    python -m benchmarks.validate_multivariate --tries-a 8  # harder budget
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import sys
+import os
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from eml_sr_hybrid import discover_hybrid  # noqa: E402
+
+
+@dataclass
+class ValidationTarget:
+    name: str
+    formula: str
+    fn: Callable[[np.ndarray], np.ndarray]
+    x_ranges: list      # list of (lo, hi) per column
+    expected_depth: int | None    # None means "unknown / probing frontier"
+    must_recover: bool            # if True, recovery failure is a test failure
+    notes: str = ""
+
+
+TARGETS: list[ValidationTarget] = [
+    ValidationTarget(
+        name="eml(x1, x2)",
+        formula="exp(x1) - ln(x2)",
+        fn=lambda X: np.exp(X[:, 0]) - np.log(X[:, 1]),
+        x_ranges=[(0.5, 2.5), (0.5, 3.0)],
+        expected_depth=1,
+        must_recover=True,
+        notes="depth-1 bivariate atom; reference for Option A recovery",
+    ),
+    ValidationTarget(
+        name="exp(x1) * exp(x2)",
+        formula="exp(x1 + x2)",
+        fn=lambda X: np.exp(X[:, 0]) * np.exp(X[:, 1]),
+        x_ranges=[(0.0, 1.0), (0.0, 1.0)],
+        expected_depth=None,
+        must_recover=False,
+        notes="needs addition inside exp; probes Option-B fallback",
+    ),
+    ValidationTarget(
+        name="x1 / x2^2",
+        formula="x1 / x2^2",
+        fn=lambda X: X[:, 0] / (X[:, 1] ** 2),
+        x_ranges=[(0.5, 3.0), (0.5, 3.0)],
+        expected_depth=None,
+        must_recover=False,
+        notes="Coulomb-like; establishes multivariate search frontier",
+    ),
+]
+
+
+def _sample_X(target: ValidationTarget, n_samples: int = 100) -> np.ndarray:
+    rng = np.random.default_rng(abs(hash(target.name)) % (2**32))
+    cols = [rng.uniform(lo, hi, n_samples) for (lo, hi) in target.x_ranges]
+    return np.stack(cols, axis=1)
+
+
+def _run_target(target: ValidationTarget, *, max_depth: int,
+                n_tries_a: int, n_tries_b: int) -> dict:
+    X = _sample_X(target)
+    y = target.fn(X)
+
+    t0 = time.time()
+    result = discover_hybrid(
+        X, y,
+        max_depth=max_depth,
+        n_tries_a=n_tries_a,
+        n_tries_b=n_tries_b,
+        verbose=False,
+    )
+    elapsed = time.time() - t0
+
+    if result is None:
+        return {
+            "target": target, "ok": False, "method": None,
+            "depth": None, "expr": None, "rmse": float("inf"),
+            "elapsed": elapsed,
+        }
+
+    # RMSE in original space — discover_hybrid reports snap_rmse which
+    # for hybrid runs is already in original space when no Normalizer
+    # is applied (the caller is responsible for normalization).
+    rmse = result["snap_rmse"]
+    return {
+        "target": target,
+        "ok": rmse < 1e-6,
+        "method": result["method"],
+        "depth": result["depth"],
+        "expr": result["expr"],
+        "rmse": rmse,
+        "elapsed": elapsed,
+    }
+
+
+def _fmt(r: dict) -> str:
+    t = r["target"]
+    ok = "✓" if r["ok"] else "✗" if t.must_recover else "·"
+    rmse = "—" if not math.isfinite(r["rmse"]) else f"{r['rmse']:.2e}"
+    depth = "—" if r["depth"] is None else str(r["depth"])
+    method = r["method"] or "—"
+    expr = (r["expr"] or "<no formula>")[:48]
+    return (f"  {ok} {t.name:22s} d={depth:>2s} rmse={rmse:>9s} "
+            f"t={r['elapsed']:6.1f}s  [{method:13s}]  → {expr}")
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Multivariate validation for discover_hybrid (issue #20)")
+    p.add_argument("--max-depth", type=int, default=3)
+    p.add_argument("--tries-a", type=int, default=4)
+    p.add_argument("--tries-b", type=int, default=2)
+    args = p.parse_args()
+
+    print("═══ Multivariate validation — discover_hybrid ═══")
+    print(f"  max_depth={args.max_depth}  "
+          f"n_tries_a={args.tries_a}  n_tries_b={args.tries_b}\n")
+    print("  target                 depth rmse        time     method         → expr")
+    print("  " + "─" * 88)
+
+    t_total = time.time()
+    results = []
+    n_must = 0
+    n_must_ok = 0
+    for tgt in TARGETS:
+        r = _run_target(
+            tgt, max_depth=args.max_depth,
+            n_tries_a=args.tries_a, n_tries_b=args.tries_b,
+        )
+        results.append(r)
+        print(_fmt(r))
+        if tgt.must_recover:
+            n_must += 1
+            if r["ok"]:
+                n_must_ok += 1
+
+    print()
+    print(f"  required recoveries: {n_must_ok}/{n_must}")
+    print(f"  total wall clock:    {time.time() - t_total:.1f}s")
+
+    # Non-zero exit if any must-recover target failed.
+    if n_must_ok < n_must:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_e2e_multivariate.py
+++ b/tests/test_e2e_multivariate.py
@@ -1,0 +1,266 @@
+"""End-to-end multivariate tests for issue #20 (Direction E [6/6]).
+
+These tests complement the existing multivariate suites:
+
+    - tests/test_multivariate.py (#15)          — tree construction, shapes,
+                                                   snap, hand-crafted leaves
+    - tests/test_curriculum_multivariate.py     — GrowingEMLTree, per-variable
+                                                   split routing, curriculum
+                                                   recovery of eml(x1, x2)
+    - tests/test_api_2d.py (#16)                — public API 2D shim
+                                                   (x → X, shape validation,
+                                                   n_vars in result dict)
+    - tests/test_normalizer_multivariate.py(#17) — per-column Normalizer
+    - tests/test_multivariate.py (sklearn, #19) — see test_eml_sr_linear.py
+                                                   / tests for sklearn wrapper
+
+What's new here (issue #20):
+
+    1. End-to-end recovery via ``discover`` (Option A, not curriculum)
+       on a genuinely bivariate target — training run, not hand-crafted.
+    2. End-to-end recovery via ``discover_hybrid`` on the same target,
+       verifying the hybrid dispatcher picks Option A and returns a
+       symbolically-clean expression.
+    3. Snap-tree callability and prediction fidelity on 2D input —
+       a recovered tree, re-run against fresh X, matches y to machine
+       precision.
+    4. Smoke test for the multivariate Feynman benchmark runner
+       (``_run_one_mv`` in ``benchmarks.feynman``): the dataclass +
+       runner accept multivariate problems without exploding.
+
+These tests train real models. They are not marked ``slow`` because
+depth-1 recovery of ``eml(x1, x2)`` fits comfortably in a single-digit
+number of seconds on CPU; empirically ~7s with ``n_tries=4``.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from eml_sr import DTYPE, REAL, discover
+from eml_sr_hybrid import discover_hybrid
+from eml_sr_linear import discover_linear
+
+
+# ═══════════════════════ Helpers ══════════════════════════════════
+
+def _bivariate_eml_target(n=100, seed=0):
+    """eml(x1, x2) = exp(x1) - ln(x2) — the depth-1 bivariate atom.
+
+    Ranges chosen so that exp(x1) stays modest (x1 ≤ 2.5 ⇒ exp ≤ 12.2)
+    and ln(x2) stays well-defined (x2 ∈ [0.5, 3.0]).
+    """
+    rng = np.random.default_rng(seed)
+    x1 = rng.uniform(0.5, 2.5, n)
+    x2 = rng.uniform(0.5, 3.0, n)
+    X = np.stack([x1, x2], axis=1)
+    y = np.exp(x1) - np.log(x2)
+    return X, y
+
+
+# ═══════════════════════ discover() recovery ═══════════════════════
+
+class TestDiscoverRecoveryMultivariate:
+    """Option A end-to-end recovery on bivariate inputs."""
+
+    def test_discover_recovers_eml_x1_x2_depth1(self):
+        """discover(X, y) with n_vars=2 recovers eml(x1, x2) at depth 1."""
+        X, y = _bivariate_eml_target()
+        result = discover(X, y, max_depth=1, n_tries=4, verbose=False)
+        assert result is not None, "discover returned None on bivariate eml"
+        assert result["depth"] == 1
+        assert result["n_vars"] == 2
+        # Machine-precision recovery (eml(x1, x2) is the literal depth-1 atom).
+        assert result["snap_rmse"] < 1e-10
+
+    def test_discover_snapped_tree_predicts_on_fresh_2d(self):
+        """Snapped tree from discover() is callable on fresh 2D input."""
+        X, y = _bivariate_eml_target()
+        result = discover(X, y, max_depth=1, n_tries=4, verbose=False)
+        assert result is not None
+        snapped = result["snapped_tree"]
+
+        # Re-evaluate on a different 2D tensor.
+        X2, y2 = _bivariate_eml_target(n=50, seed=1)
+        X2_t = torch.tensor(X2, dtype=REAL)
+        with torch.no_grad():
+            pred, _, _ = snapped(X2_t, tau=0.01)
+        pred_np = pred.real.detach().numpy()
+        rmse = float(np.sqrt(np.mean((pred_np - y2) ** 2)))
+        assert rmse < 1e-10
+
+
+# ═══════════════════════ discover_hybrid() dispatch ════════════════
+
+class TestDiscoverHybridMultivariate:
+    """Hybrid dispatcher on bivariate inputs: Option A should win here."""
+
+    def test_hybrid_picks_option_a_on_depth1_bivariate(self):
+        """For a clean depth-1 target, hybrid returns via option_a."""
+        X, y = _bivariate_eml_target()
+        result = discover_hybrid(
+            X, y,
+            max_depth=1, n_tries_a=4, n_tries_b=2,
+            verbose=False,
+        )
+        assert result is not None
+        # Option A is supposed to succeed cleanly on this; falling back
+        # would signal a regression in the dispatcher's threshold logic.
+        assert result["method"] == "option_a"
+        assert result["n_vars"] == 2
+        assert result["snap_rmse"] < 1e-10
+        # Expression should reference both variables.
+        assert "x1" in result["expr"]
+        assert "x2" in result["expr"]
+
+    def test_hybrid_result_has_multivariate_contract(self):
+        """Hybrid result dict has all required multivariate fields."""
+        X, y = _bivariate_eml_target(n=50)
+        result = discover_hybrid(
+            X, y,
+            max_depth=1, n_tries_a=2, n_tries_b=1,
+            verbose=False,
+        )
+        assert result is not None
+        for key in ("expr", "depth", "snap_rmse", "snapped_tree",
+                    "n_vars", "method"):
+            assert key in result, f"missing result key: {key}"
+        assert result["method"] in ("option_a", "warm_start_a", "option_b")
+
+
+# ═══════════════════════ Linear tree on bivariate addition ═════════
+
+class TestDiscoverLinearMultivariate:
+    """Option B on a target that depends on a linear combination of inputs.
+
+    ``exp(x1 + x2)`` is NOT in Option A's depth-1 vocabulary — there is no
+    addition atom. Option B's affine leaves (α + β₁x₁ + β₂x₂) *can*
+    represent the inner sum, so a depth-1 B tree should reach it.
+    """
+
+    def test_linear_fits_exp_of_sum(self):
+        """Option B depth-1 should achieve low snap RMSE on exp(x1+x2)."""
+        rng = np.random.default_rng(0)
+        n = 100
+        x1 = rng.uniform(0.0, 1.0, n)
+        x2 = rng.uniform(0.0, 1.0, n)
+        X = np.stack([x1, x2], axis=1)
+        y = np.exp(x1 + x2)
+
+        result = discover_linear(
+            X, y, max_depth=1, n_tries=4, verbose=False,
+        )
+        assert result is not None
+        assert result["n_vars"] == 2
+        # Option B is numerical, not symbolic. We accept a loose RMSE
+        # because the affine leaves should close on x1+x2 under gradient
+        # descent but need not hit float64 precision in 4 tries. The
+        # point is it's *reachable* by Option B; a catastrophic failure
+        # (rmse ~ O(y)) signals a regression in the 2D linear path.
+        # y has range exp(0)..exp(2) ≈ 1..7.4; 0.15 is ~2% of signal.
+        assert result["snap_rmse"] < 0.15
+
+
+# ═══════════════════════ Feynman benchmark (multivariate) ══════════
+
+class TestFeynmanMultivariateRunner:
+    """Smoke tests for the multivariate additions to benchmarks.feynman."""
+
+    def test_feynman_problem_multivariate_dataclass(self):
+        """FeynmanProblem accepts n_vars + x_ranges for multivariate."""
+        from benchmarks.feynman import FeynmanProblem
+
+        p = FeynmanProblem(
+            feynman_id="TEST.mv",
+            name="bivariate-eml",
+            formula="exp(x1) - ln(x2)",
+            fn=lambda X: np.exp(X[:, 0]) - np.log(X[:, 1]),
+            x_ranges=[(0.5, 2.5), (0.5, 3.0)],
+            n_vars=2,
+            n_samples=50,
+        )
+        assert p.n_vars == 2
+        assert len(p.x_ranges) == 2
+
+    def test_feynman_problem_univariate_backward_compat(self):
+        """Univariate FeynmanProblem (x_range tuple) still works."""
+        from benchmarks.feynman import FeynmanProblem
+
+        p = FeynmanProblem(
+            feynman_id="TEST.uv",
+            name="univariate",
+            formula="exp(x)",
+            fn=lambda x: np.exp(x),
+            x_range=(0.5, 2.5),
+        )
+        # n_vars defaults to 1; x_ranges is synthesized from x_range.
+        assert p.n_vars == 1
+        # Sampling (done via _sample_X) produces 1D for backward compat.
+
+    def test_feynman_mv_sampling_shape(self):
+        """Multivariate sampler returns X of shape (n_samples, n_vars)."""
+        from benchmarks.feynman import FeynmanProblem, _sample_X
+
+        p = FeynmanProblem(
+            feynman_id="TEST.mv",
+            name="bivariate",
+            formula="exp(x1) - ln(x2)",
+            fn=lambda X: np.exp(X[:, 0]) - np.log(X[:, 1]),
+            x_ranges=[(0.5, 2.5), (0.5, 3.0)],
+            n_vars=2,
+            n_samples=40,
+        )
+        X = _sample_X(p)
+        assert X.shape == (40, 2)
+        # Columns should lie in the declared ranges.
+        assert 0.5 <= X[:, 0].min() <= X[:, 0].max() <= 2.5
+        assert 0.5 <= X[:, 1].min() <= X[:, 1].max() <= 3.0
+
+    def test_feynman_uv_sampling_shape(self):
+        """Univariate sampler returns 1D x (backward compat)."""
+        from benchmarks.feynman import FeynmanProblem, _sample_X
+
+        p = FeynmanProblem(
+            feynman_id="TEST.uv",
+            name="univariate",
+            formula="exp(x)",
+            fn=lambda x: np.exp(x),
+            x_range=(0.5, 2.5),
+            n_samples=30,
+        )
+        x = _sample_X(p)
+        assert x.ndim == 1
+        assert x.shape == (30,)
+
+    def test_run_one_mv_executes(self):
+        """_run_one on a bivariate problem returns a result dict."""
+        from benchmarks.feynman import FeynmanProblem, _run_one
+
+        p = FeynmanProblem(
+            feynman_id="TEST.mv.eml",
+            name="depth1-bivariate",
+            formula="exp(x1) - ln(x2)",
+            fn=lambda X: np.exp(X[:, 0]) - np.log(X[:, 1]),
+            x_ranges=[(0.5, 2.5), (0.5, 3.0)],
+            n_vars=2,
+            n_samples=40,
+        )
+        r = _run_one(
+            p,
+            max_depth=1, n_tries=2, method="curriculum",
+            normalize="none", n_workers=1, threshold=1e-6,
+        )
+        assert "ok" in r
+        assert "elapsed" in r
+        assert "rmse" in r
+        assert "depth" in r
+        # Depth-1 eml(x1, x2) should actually recover with only n_tries=2
+        # since it is the literal leaf atom; if this flakes in CI we'd
+        # bump n_tries or mark slow. Empirically reliable on CPU.
+        assert r["ok"] is True, f"expected recovery, got {r}"
+        assert math.isfinite(r["rmse"])
+        assert r["rmse"] < 1e-6


### PR DESCRIPTION
Closes #20. Final piece of Direction E (multivariate extension).

## What

- **10 new end-to-end tests** (`tests/test_e2e_multivariate.py`) covering recovery via `discover` / `discover_hybrid` / `discover_linear` on bivariate targets, plus smoke tests for the multivariate Feynman runner.
- **FeynmanProblem → multivariate**: new `n_vars` (default 1) and `x_ranges` fields. `x_range` preserved as legacy univariate and synthesized into `x_ranges` via `__post_init__`, so every existing univariate row is unchanged.
- **Five new multivariate Feynman problems**: `mv.eml` (depth-1 atom), `mv.expsum` (addition-in-exp), `II.6.15a` coulomb-2var, `mv.ln-ratio`, `mv.sum-exp`.
- **`benchmarks/validate_multivariate.py`**: discover_hybrid validation across the difficulty spectrum (must-recover depth-1 atom → frontier probes). Nonzero exit if the required recovery fails.

## Verified

- `tests/test_e2e_multivariate.py`: all 10 tests pass (~130s total — training runs for the recovery tests).
- Existing multivariate suites still green (`test_multivariate.py`, `test_api_2d.py`, `test_normalizer_multivariate.py`, `test_curriculum_multivariate.py`).
- Manual: `discover_hybrid` recovers `eml(x1, x2)` at depth 1 via `option_a` in ~22s on CPU.
- Manual: `exp(x1) * exp(x2)` at max_depth=3, n_tries=8 times out at 180s — this is the frontier the validation script is designed to probe, not a recovery target.

## Acceptance criteria

- [x] All existing tests pass (backward compat)
- [x] New multivariate tests pass
- [x] `eml(x1, x2)` recovers at depth 1 with machine precision
- [x] Feynman benchmark runs end-to-end with multivariate problems
- [x] Results documented in `validate_multivariate.py`

## Notes

PR scope is pure test/benchmark/validation surface — no changes to production code paths. All underlying 2D plumbing was landed in the earlier Direction E PRs (#24, #26, #27, #28). The issue anticipated ~20 new tests; in practice most of the suggested cases were already covered by the per-PR test additions across #16–#19, so this PR focuses on the genuinely new coverage: end-to-end recovery and benchmark integration.