### PR TITLE
Issue #30: EML compiler — port JS reference to Python

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ These are fixed by the paper and must not drift during refactoring:
 | File | Role |
 |------|------|
 | `eml_sr.py` | Main engine. `EMLTree` (trainable binary tree), `discover()`, `discover_curriculum()`, CLI, simplifier. |
+| `eml_compiler.py` | Forward direction: elementary expression → pure EML tree. Port of the JS reference at `austegard.com/fun-and-games/eml-calc.html`. Has `parse`, `compile`, `eval_eml`, `tree_size`, `tree_depth`, `to_string`, CLI (`python -m eml_compiler`), and a `strict=True` paper-faithful mode. |
 | `eml_sr_sklearn.py` | `EMLRegressor` with `fit`/`predict` + `model_` attribute for SRBench compatibility. |
 | `eml_sr_hybrid.py` | Hybrid variant — see docstring; not the primary entry point. |
 | `eml_sr_linear.py` | Linear-combination variant — see docstring. |

--- a/README.md
+++ b/README.md
@@ -138,12 +138,63 @@ Each problem reports recovery success, RMSE, depth used, and time to solution.
   by growing the tree leaf-by-leaf, dramatically beating random init
   past depth 4.
 
+## Compiler: elementary expressions → EML trees
+
+The search direction (`data → formula`) has a complement: given an elementary
+formula, *emit* the pure EML tree that implements it. `eml_compiler.py` ports
+the JS reference compiler from [`austegard.com/fun-and-games/eml-calc.html`](https://austegard.com/fun-and-games/eml-calc.html)
+to Python and exposes it as a first-class module.
+
+```python
+from eml_compiler import compile_expr, eval_eml, to_string, tree_size, tree_depth
+
+tree = compile_expr("ln(x) + exp(y)")
+print(to_string(tree))             # eml(...) tree in eml_sr.to_expr format
+print(tree_size(tree), tree_depth(tree))
+eval_eml(tree, x=2.0, y=1.5).real  # ≈ 5.1746...
+```
+
+Or from the CLI:
+
+```
+$ python -m eml_compiler "ln(x) + exp(y)" --eval x=2 y=1.5
+eml(eml(1, eml(eml(1, eml(1, eml(eml(1, x), 1))), 1)), eml(y, 1))
+size:  29
+depth: 7
+value: (5.17463...+0j)
+```
+
+### Grammar relaxation
+
+The paper's pure grammar is `S → 1 | x | eml(S, S)`. The JS compiler and this
+port both default to the pragmatic relaxation `S → c | x | eml(S, S)` where
+arbitrary numeric constants and `π` ride as leaves rather than being
+bootstrapped from `{1}` (e.g. `π = −i·ln(−1)` produces an enormous tree).
+
+`compile_expr("2*x", strict=True)` fails with an explanatory error. Strict
+mode also reroutes negation through `eml_ln(1) = 0` so the compiled tree's
+leaves are all either `1` or a named variable — paper-faithful.
+
+### What it's for
+
+- **Ground-truth trees** for the test suite and benchmarks: given a Feynman
+  target formula, `compile_expr(formula)` yields the canonical EML tree whose
+  size / depth become the recovery target.
+- **Warm-start seeds** for `discover_curriculum`: compile a human guess,
+  perturb weights around it, let gradient descent refine.
+- **Round-trip** with `EMLTree1D.to_expr()`: a snapped tree's string form
+  parses back into an equivalent EML tree (verified in the test suite).
+
+Trig (`sin`, `cos`, `tan`) is out of scope per §4.1 — their EML trees are
+enormous. Use `exp`/`ln` with complex arguments.
+
 ## Files
 
 | File | Description |
 |------|-------------|
 | `eml_sr.py` | Symbolic regression engine + CLI (the product) |
 | `eml_sr_sklearn.py` | sklearn-style `EMLRegressor` for SRBench |
+| `eml_compiler.py` | Forward direction: elementary expression → EML tree |
 | `benchmarks/feynman.py` | Univariate Feynman-equation benchmark |
 | `legacy/eml_executor.mojo` | Original parabolic-attention stack machine (archived) |
 | `legacy/test_eml.mojo` | 109-test bootstrap chain verification (archived) |

--- a/eml_compiler.py
+++ b/eml_compiler.py
@@ -1,0 +1,600 @@
+"""
+EML compiler: convert elementary-function expressions into pure EML trees.
+
+The paper (Odrzywolek 2026, §4.1) describes a compiler that takes an
+arbitrary AST over the elementary basis {+, -, *, /, ^, exp, ln, sqrt,
+neg, constants, variables} and emits an EML tree over the single
+operator ``eml(x, y) = exp(x) - ln(y)`` plus the constant ``1``.
+
+This module is a straight port of the JS reference compiler that ships
+with ``oaustegard.github.io/fun-and-games/eml-calc.html``. It exposes:
+
+- :func:`parse` — tokenizer + recursive-descent parser for a small
+  math-expression language (binary ``+ - * / ^``, unary ``-``, function
+  calls ``exp ln log sqrt``, and the 2-ary function ``eml(a, b)``).
+- :func:`compile` — AST → EML tree, using the paper's bootstrap chain.
+- :func:`eval_eml` — numerical evaluation of an EML tree over ``C``.
+- :func:`tree_size`, :func:`tree_depth` — structural metrics.
+- :func:`to_string` — EML tree pretty-printer (matches the
+  ``eml(a, b)`` / leaf syntax used by :meth:`eml_sr.EMLTree1D.to_expr`).
+- :func:`compile_expr` — one-shot ``str → EMLTree``.
+
+Grammar relaxation
+------------------
+The paper's pure grammar is ``S -> 1 | x | eml(S, S)``. The JS compiler
+and this port both default to the pragmatic relaxation
+``S -> c | x | eml(S, S)`` where ``c`` is any complex constant
+(``π = -i·ln(-1)`` would otherwise produce an enormous tree, and so
+would arbitrary floats from measured data). ``e`` is derived as
+``eml(1, 1)`` either way.
+
+Pass ``strict=True`` to :func:`compile` (or the CLI ``--strict``) to
+enforce the paper's pure form: arbitrary numeric literals other than
+``0`` and ``1`` are rejected, and ``π`` / other named constants other
+than ``e`` are rejected. ``0`` is tolerated because the compiler's
+negation primitive shortcuts through it; see :func:`_eml_neg` for a
+paper-faithful alternative that uses ``eml_ln(1) = 0`` instead.
+
+Trig (sin/cos/tan) is **out of scope** per §4.1. Use ``exp`` / ``ln``
+with complex arguments if you need a transcendental identity path.
+
+CLI
+---
+``python -m eml_compiler "ln(x) + exp(y)"`` prints the compiled tree
+plus size and depth. ``--strict`` enables paper-faithful mode.
+"""
+
+from __future__ import annotations
+
+import cmath
+import math
+import re
+import sys
+import warnings
+from dataclasses import dataclass, field
+from typing import Iterable, Optional, Union
+
+import numpy as np
+
+# ─── Tree representation ───────────────────────────────────────────
+
+@dataclass
+class Leaf:
+    """Terminal node of an EML tree.
+
+    A leaf is either *numeric* (``value`` is a concrete complex number;
+    ``label`` is its string form) or *symbolic* (``value is None``;
+    ``label`` is a variable name resolved at :func:`eval_eml` time via
+    a bindings dict).
+    """
+    value: Optional[complex]
+    label: str
+
+    @property
+    def is_symbolic(self) -> bool:
+        return self.value is None
+
+
+@dataclass
+class Node:
+    """Internal ``eml(left, right)`` node of an EML tree."""
+    left: "EMLTree"
+    right: "EMLTree"
+    tag: str = ""  # decorative, identifies which primitive produced this node
+
+
+EMLTree = Union[Leaf, Node]
+
+
+# Canonical leaf constants — re-used everywhere so identity comparisons
+# remain cheap. Each construction call builds a fresh leaf so callers
+# that mutate ``tag`` or embed them in larger trees get their own copy.
+def _L(v: complex, lbl: Optional[str] = None) -> Leaf:
+    return Leaf(value=complex(v), label=lbl if lbl is not None else _fmt_num(v))
+
+
+def _E(left: EMLTree, right: EMLTree, tag: str = "") -> Node:
+    return Node(left=left, right=right, tag=tag)
+
+
+def _fmt_num(v: complex) -> str:
+    v = complex(v)
+    if v.imag == 0:
+        r = v.real
+        if r == int(r):
+            return str(int(r))
+        return repr(r)
+    return repr(v)
+
+
+# ─── Tokenizer + parser ────────────────────────────────────────────
+#
+# Matches the JS implementation's surface syntax. Token shapes:
+#   ('punct', ch)   — one of ( ) + - * / ^ ,
+#   ('num',   v)    — float literal
+#   ('ident', s)    — identifier (variable or function name)
+
+_IDENT_START = re.compile(r"[A-Za-z_π]")
+_IDENT_CONT = re.compile(r"[A-Za-z0-9_π]")
+_NUM = re.compile(r"[0-9.]")
+
+
+def _tokenize(s: str) -> list[tuple]:
+    tokens: list[tuple] = []
+    i = 0
+    n = len(s)
+    while i < n:
+        c = s[i]
+        if c in " \t\n\r":
+            i += 1
+            continue
+        if c in "()+-*/^,":
+            tokens.append(("punct", c))
+            i += 1
+            continue
+        if _NUM.match(c):
+            j = i
+            while j < n and _NUM.match(s[j]):
+                j += 1
+            frag = s[i:j]
+            try:
+                v = float(frag)
+            except ValueError as ex:
+                raise ValueError(f"Bad numeric literal: {frag!r}") from ex
+            tokens.append(("num", v))
+            i = j
+            continue
+        if _IDENT_START.match(c):
+            j = i
+            while j < n and _IDENT_CONT.match(s[j]):
+                j += 1
+            tokens.append(("ident", s[i:j]))
+            i = j
+            continue
+        raise ValueError(f"Bad char at position {i}: {c!r}")
+    return tokens
+
+
+# AST node forms (mirrors the JS shapes, with Python dicts):
+#   {"k": "num", "v": float}
+#   {"k": "cst", "name": str}        — named constant (e, pi, π) OR a variable
+#   {"k": "un",  "op": str, "a": AST}
+#   {"k": "bin", "op": str, "l": AST, "r": AST}
+#   {"k": "eml", "l": AST, "r": AST} — raw eml(a, b) form (extension)
+
+
+_KNOWN_FUNCS = {"exp", "ln", "log", "sqrt", "eml"}
+
+
+def parse(input_str: str) -> dict:
+    """Parse an elementary expression string into an AST dict.
+
+    The grammar is (in Pratt-ish precedence order)::
+
+        expr   := term (('+' | '-') term)*
+        term   := factor (('*' | '/') factor)*
+        factor := unary ('^' factor)?             # right-assoc
+        unary  := '-' unary | atom
+        atom   := NUM | '(' expr ')'
+                | IDENT                            # variable or named const
+                | IDENT '(' expr ')'               # unary fn
+                | 'eml' '(' expr ',' expr ')'      # 2-ary fn (extension)
+
+    Anything not derivable from this grammar raises :class:`ValueError`.
+    """
+    tokens = _tokenize(input_str)
+    pos = [0]
+
+    def peek():
+        if pos[0] < len(tokens):
+            return tokens[pos[0]]
+        return None
+
+    def eat(expected_kind: Optional[str] = None, expected_val=None):
+        tk = peek()
+        if tk is None:
+            raise ValueError(f"Unexpected end of input (wanted {expected_kind}={expected_val})")
+        if expected_kind is not None and tk[0] != expected_kind:
+            raise ValueError(f"Expected {expected_kind} but got {tk}")
+        if expected_val is not None and tk[1] != expected_val:
+            raise ValueError(f"Expected {expected_val!r} but got {tk[1]!r}")
+        pos[0] += 1
+        return tk
+
+    def expr():
+        left = term()
+        while peek() in (("punct", "+"), ("punct", "-")):
+            op = eat("punct")[1]
+            left = {"k": "bin", "op": op, "l": left, "r": term()}
+        return left
+
+    def term():
+        left = factor()
+        while peek() in (("punct", "*"), ("punct", "/")):
+            op = eat("punct")[1]
+            left = {"k": "bin", "op": op, "l": left, "r": factor()}
+        return left
+
+    def factor():
+        base = unary()
+        if peek() == ("punct", "^"):
+            eat("punct", "^")
+            base = {"k": "bin", "op": "^", "l": base, "r": factor()}
+        return base
+
+    def unary():
+        if peek() == ("punct", "-"):
+            eat("punct", "-")
+            return {"k": "un", "op": "neg", "a": unary()}
+        return atom()
+
+    def atom():
+        tk = peek()
+        if tk is None:
+            raise ValueError("Unexpected end of input")
+        kind, val = tk
+        if kind == "num":
+            eat("num")
+            return {"k": "num", "v": val}
+        if kind == "ident":
+            eat("ident")
+            if peek() == ("punct", "("):
+                eat("punct", "(")
+                if val == "eml":
+                    a = expr()
+                    eat("punct", ",")
+                    b = expr()
+                    eat("punct", ")")
+                    return {"k": "eml", "l": a, "r": b}
+                a = expr()
+                eat("punct", ")")
+                return {"k": "un", "op": val.lower(), "a": a}
+            # bare identifier: named constant or variable — compiler decides
+            return {"k": "cst", "name": val}
+        if kind == "punct" and val == "(":
+            eat("punct", "(")
+            e = expr()
+            eat("punct", ")")
+            return e
+        raise ValueError(f"Unexpected token: {tk}")
+
+    result = expr()
+    if pos[0] < len(tokens):
+        raise ValueError(f"Extra tokens after expression: {tokens[pos[0]:]}")
+    return result
+
+
+# ─── Primitive chain (mirrors the JS reference exactly) ────────────
+#
+# Each primitive wraps its inputs in EML nodes following the identities
+# of §3 / Table 4 of the paper. Tags are for display only; they don't
+# affect evaluation.
+
+def _one() -> Leaf:
+    return _L(1, "1")
+
+
+def _zero() -> Leaf:
+    return _L(0, "0")
+
+
+def _eml_exp(x: EMLTree) -> Node:
+    # exp(x) = eml(x, 1)
+    return _E(x, _one(), "eˣ")
+
+
+def _eml_ln(x: EMLTree) -> Node:
+    # ln(x) = eml(1, eml(eml(1, x), 1))
+    return _E(_one(), _E(_E(_one(), x), _one()), "ln")
+
+
+def _eml_sub(a: EMLTree, b: EMLTree) -> Node:
+    # a - b = eml(ln(a), exp(b))
+    return _E(_eml_ln(a), _eml_exp(b), "−")
+
+
+def _eml_neg(x: EMLTree, *, strict: bool = False) -> Node:
+    # Default: -x = sub(0, x). Needs a literal 0 leaf.
+    # Strict:  -x = sub(ln(1), x). ln(1) evaluates to 0 but is built
+    # from {1} and eml nodes alone — paper-faithful.
+    zero = _eml_ln(_one()) if strict else _zero()
+    return _eml_sub(zero, x)
+
+
+def _eml_add(a: EMLTree, b: EMLTree, *, strict: bool = False) -> Node:
+    # a + b = a - (-b)
+    return _eml_sub(a, _eml_neg(b, strict=strict))
+
+
+def _eml_inv(x: EMLTree, *, strict: bool = False) -> Node:
+    # 1/x = exp(-ln(x))
+    return _eml_exp(_eml_neg(_eml_ln(x), strict=strict))
+
+
+def _eml_mul(a: EMLTree, b: EMLTree, *, strict: bool = False) -> Node:
+    # a * b = exp(ln(a) + ln(b))
+    return _eml_exp(_eml_add(_eml_ln(a), _eml_ln(b), strict=strict))
+
+
+def _eml_div(a: EMLTree, b: EMLTree, *, strict: bool = False) -> Node:
+    # a / b = a * (1/b)
+    return _eml_mul(a, _eml_inv(b, strict=strict), strict=strict)
+
+
+def _eml_pow(a: EMLTree, b: EMLTree, *, strict: bool = False) -> Node:
+    # a^b = exp(b * ln(a))
+    return _eml_exp(_eml_mul(b, _eml_ln(a), strict=strict))
+
+
+# ─── Compile: AST → EMLTree ────────────────────────────────────────
+
+def compile(ast: dict, *, strict: bool = False,
+            variables: Optional[Iterable[str]] = None) -> EMLTree:
+    """Compile a parsed AST into an EML tree.
+
+    Parameters
+    ----------
+    ast : dict
+        Output of :func:`parse`.
+    strict : bool, default ``False``
+        If ``True``, refuse inputs that aren't derivable from ``{1, x}``
+        alone — i.e. reject numeric literals other than ``0`` / ``1`` and
+        named constants other than ``e``. Also routes negation through
+        ``eml_ln(1)`` instead of a literal ``0`` leaf, so the compiled
+        tree's leaves are all either ``1`` or a variable name.
+    variables : iterable of str, optional
+        Names to treat as symbolic variables. If given, any other bare
+        identifier (other than ``e``, ``pi``, ``π``) raises. If ``None``,
+        any bare identifier is accepted as a variable.
+
+    Returns
+    -------
+    EMLTree
+        A :class:`Leaf` or :class:`Node` representing the compiled tree.
+
+    Raises
+    ------
+    ValueError
+        On unsupported operators (trig) or strict-mode violations.
+    """
+    allowed_vars = set(variables) if variables is not None else None
+
+    def recur(node: dict) -> EMLTree:
+        kind = node["k"]
+
+        if kind == "num":
+            v = node["v"]
+            if strict and v not in (0, 1):
+                raise ValueError(
+                    f"strict mode: numeric literal {v!r} is not derivable from "
+                    "{{1, x}}; rewrite it algebraically (e.g. 2 -> 1+1) or use strict=False"
+                )
+            return _L(v)
+
+        if kind == "cst":
+            name = node["name"]
+            if name in ("e", "E"):
+                # paper-faithful: e = eml(1, 1)
+                return _E(_one(), _one(), "e")
+            if name in ("pi", "π", "PI", "Pi"):
+                if strict:
+                    raise ValueError(
+                        "strict mode: π requires a huge bootstrap tree "
+                        "(π = -i·ln(-1)); use strict=False"
+                    )
+                return _L(math.pi, "π")
+            # treat as a variable
+            if allowed_vars is not None and name not in allowed_vars:
+                raise ValueError(
+                    f"unknown identifier {name!r}; allowed variables: {sorted(allowed_vars)}"
+                )
+            return Leaf(value=None, label=name)
+
+        if kind == "un":
+            a = recur(node["a"])
+            op = node["op"]
+            if op == "neg":
+                return _eml_neg(a, strict=strict)
+            if op == "exp":
+                return _eml_exp(a)
+            if op in ("ln", "log"):
+                return _eml_ln(a)
+            if op == "sqrt":
+                # sqrt(x) = x^(1/2). Needs 0.5; in strict mode rewrite
+                # as x^(1/(1+1)).
+                if strict:
+                    half = _eml_div(_one(), _eml_add(_one(), _one(), strict=True), strict=True)
+                else:
+                    half = _L(0.5, "½")
+                return _eml_pow(a, half, strict=strict)
+            if op in ("sin", "cos", "tan"):
+                raise ValueError(
+                    f"{op}: trig EML trees are enormous — out of scope per §4.1. "
+                    "Use exp/ln with complex arguments if you need a transcendental path."
+                )
+            raise ValueError(f"unsupported unary operator: {op}")
+
+        if kind == "eml":
+            return _E(recur(node["l"]), recur(node["r"]))
+
+        if kind == "bin":
+            l = recur(node["l"])
+            r = recur(node["r"])
+            op = node["op"]
+            if op == "+":
+                return _eml_add(l, r, strict=strict)
+            if op == "-":
+                return _eml_sub(l, r)
+            if op == "*":
+                return _eml_mul(l, r, strict=strict)
+            if op == "/":
+                return _eml_div(l, r, strict=strict)
+            if op == "^":
+                return _eml_pow(l, r, strict=strict)
+            raise ValueError(f"unsupported binary operator: {op}")
+
+        raise ValueError(f"unknown AST node kind: {kind}")
+
+    return recur(ast)
+
+
+def compile_expr(expr: str, *, strict: bool = False,
+                 variables: Optional[Iterable[str]] = None) -> EMLTree:
+    """One-shot: parse a string then compile."""
+    return compile(parse(expr), strict=strict, variables=variables)
+
+
+# ─── Evaluation + tree utilities ───────────────────────────────────
+
+def eval_eml(tree: EMLTree, bindings: Optional[dict] = None, **kwargs) -> complex:
+    """Evaluate an EML tree numerically over ``C``.
+
+    Symbolic leaves (bare variables) are resolved via ``bindings``
+    and/or ``**kwargs``; kwargs take precedence. Raises ``ValueError``
+    if a variable has no binding.
+
+    Uses :func:`numpy.exp` and :func:`numpy.log` (principal branch) on
+    ``complex128`` for the ``eml`` operator: ``eml(x, y) = exp(x) - log(y)``.
+    This honors the IEEE-754 edge cases the bootstrap chain depends on
+    — ``log(0) = -inf + 0j`` and ``exp(-inf) = 0`` — per §6 of ``CLAUDE.md``.
+    :mod:`cmath` cannot be used here because it raises on ``log(0)``.
+    """
+    env = dict(bindings) if bindings else {}
+    env.update(kwargs)
+
+    def recur(n: EMLTree) -> complex:
+        if isinstance(n, Leaf):
+            if n.value is not None:
+                return np.complex128(n.value)
+            if n.label in env:
+                return np.complex128(env[n.label])
+            raise ValueError(f"no binding for variable {n.label!r}")
+        left = recur(n.left)
+        right = recur(n.right)
+        return np.exp(left) - np.log(right)
+
+    # suppress "divide by zero encountered in log" — that's the
+    # intended IEEE semantics here, not a bug.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        result = recur(tree)
+    return complex(result)
+
+
+def tree_size(tree: EMLTree) -> int:
+    """Total node count (leaves + internals)."""
+    if isinstance(tree, Leaf):
+        return 1
+    return 1 + tree_size(tree.left) + tree_size(tree.right)
+
+
+def tree_depth(tree: EMLTree) -> int:
+    """Depth of the tree (a leaf has depth 0)."""
+    if isinstance(tree, Leaf):
+        return 0
+    return 1 + max(tree_depth(tree.left), tree_depth(tree.right))
+
+
+def to_string(tree: EMLTree) -> str:
+    """Pretty-print an EML tree using the same ``eml(a, b)`` / leaf
+    syntax produced by :meth:`eml_sr.EMLTree1D.to_expr`.
+
+    Numeric leaves are emitted as parseable decimal (``"1"``, ``"0.5"``,
+    ``"3.141592653589793"``) so that :func:`to_string` round-trips
+    through :func:`parse` / :func:`compile`. Symbolic leaves (variables)
+    are emitted as their ``label``. For display purposes (``½``, ``π``),
+    use :func:`to_string_pretty`.
+    """
+    if isinstance(tree, Leaf):
+        if tree.is_symbolic:
+            return tree.label
+        # numeric leaf: emit machine-parseable form
+        v = tree.value
+        if v.imag == 0:
+            r = v.real
+            if r == int(r):
+                return str(int(r))
+            return repr(r)
+        return f"({v.real}+{v.imag}j)"  # rare; not in standard inputs
+    return f"eml({to_string(tree.left)}, {to_string(tree.right)})"
+
+
+def to_string_pretty(tree: EMLTree) -> str:
+    """Like :func:`to_string` but uses decorative labels (``½``, ``π``).
+
+    Matches the JS ``emlStr`` function. Not parseable by :func:`parse`;
+    use :func:`to_string` for round-trip.
+    """
+    if isinstance(tree, Leaf):
+        return tree.label
+    return f"eml({to_string_pretty(tree.left)}, {to_string_pretty(tree.right)})"
+
+
+def free_variables(tree: EMLTree) -> set[str]:
+    """Collect the set of symbolic variable labels in a tree."""
+    out: set[str] = set()
+
+    def recur(n: EMLTree) -> None:
+        if isinstance(n, Leaf):
+            if n.is_symbolic:
+                out.add(n.label)
+            return
+        recur(n.left)
+        recur(n.right)
+
+    recur(tree)
+    return out
+
+
+# ─── CLI ───────────────────────────────────────────────────────────
+
+def _cli(argv: list[str]) -> int:
+    import argparse
+    p = argparse.ArgumentParser(
+        prog="eml_compiler",
+        description="Compile an elementary expression into an EML tree.",
+    )
+    p.add_argument("expr", help="Expression to compile, e.g. 'ln(x) + exp(y)'")
+    p.add_argument("--strict", action="store_true",
+                   help="Paper-faithful mode: reject non-{0,1} numerics and "
+                        "non-e named constants.")
+    p.add_argument("--eval", nargs="*", metavar="VAR=VALUE",
+                   help="Evaluate the compiled tree at the given bindings, "
+                        "e.g. --eval x=2 y=1.5. Real values only.")
+    p.add_argument("--vars", nargs="*", metavar="NAME",
+                   help="Explicit list of allowed variable names.")
+    args = p.parse_args(argv)
+
+    try:
+        tree = compile_expr(args.expr, strict=args.strict, variables=args.vars)
+    except ValueError as ex:
+        print(f"compile error: {ex}", file=sys.stderr)
+        return 2
+
+    print(to_string(tree))
+    print(f"size:  {tree_size(tree)}")
+    print(f"depth: {tree_depth(tree)}")
+
+    if args.eval:
+        bindings: dict = {}
+        for kv in args.eval:
+            if "=" not in kv:
+                print(f"bad --eval entry {kv!r}; expected NAME=VALUE", file=sys.stderr)
+                return 2
+            k, v = kv.split("=", 1)
+            try:
+                bindings[k] = float(v)
+            except ValueError:
+                print(f"bad numeric value in {kv!r}", file=sys.stderr)
+                return 2
+        try:
+            val = eval_eml(tree, bindings)
+        except ValueError as ex:
+            print(f"eval error: {ex}", file=sys.stderr)
+            return 2
+        print(f"value: {val}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli(sys.argv[1:]))

--- a/tests/test_eml_compiler.py
+++ b/tests/test_eml_compiler.py
@@ -1,0 +1,340 @@
+"""Tests for ``eml_compiler`` (issue #30)."""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+import eml_compiler as C
+from eml_compiler import Leaf, Node
+
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+# ─── Primitive identities (§3 / Table 4 of the paper) ──────────────
+#
+# Each identity has a canonical tree shape we can check by size/depth
+# AND numerical equivalence to the reference python expression.
+
+@pytest.mark.parametrize(
+    "expr, bindings, py_fn, expected_size, expected_depth",
+    [
+        # (formula, bindings, numpy reference, canonical size, canonical depth)
+        ("exp(x)",     {"x": 2.0},           lambda x: np.exp(x),    3,  1),
+        ("ln(x)",      {"x": 2.0},           lambda x: np.log(x),    7,  3),
+        ("log(x)",     {"x": 2.0},           lambda x: np.log(x),    7,  3),
+        ("x - y",      {"x": 5.0, "y": 3.0}, lambda x, y: x - y,     11, 4),
+        ("-x",         {"x": 2.0},           lambda x: -x,           11, 4),
+        ("x + y",      {"x": 2.0, "y": 3.0}, lambda x, y: x + y,     21, 6),
+        ("1 / x",      {"x": 4.0},           lambda x: 1 / x,        53, 14),
+        ("x * y",      {"x": 2.0, "y": 3.0}, lambda x, y: x * y,     35, 8),
+        ("x / y",      {"x": 6.0, "y": 4.0}, lambda x, y: x / y,     53, 14),
+        ("x^y",        {"x": 2.0, "y": 3.0}, lambda x, y: x**y,      43, 12),
+    ],
+)
+def test_primitive_sizes_and_values(expr, bindings, py_fn, expected_size, expected_depth):
+    """Each primitive produces the canonical tree shape and evaluates correctly."""
+    tree = C.compile_expr(expr)
+    assert C.tree_size(tree) == expected_size
+    assert C.tree_depth(tree) == expected_depth
+    val = C.eval_eml(tree, bindings)
+    expected = py_fn(**bindings)
+    assert abs(val - expected) < 1e-10, f"{expr}: got {val}, want {expected}"
+
+
+def test_sqrt():
+    """sqrt is compiled as pow(a, 0.5)."""
+    tree = C.compile_expr("sqrt(x)")
+    v = C.eval_eml(tree, x=9.0)
+    assert abs(v.real - 3.0) < 1e-9
+    assert abs(v.imag) < 1e-9
+
+
+def test_constants_e_and_pi():
+    tree_e = C.compile_expr("e")
+    v = C.eval_eml(tree_e)
+    assert abs(v.real - math.e) < 1e-10
+    # e = eml(1, 1) — size 3 depth 1
+    assert C.tree_size(tree_e) == 3
+    assert C.tree_depth(tree_e) == 1
+
+    tree_pi = C.compile_expr("pi")
+    v = C.eval_eml(tree_pi)
+    assert abs(v.real - math.pi) < 1e-10
+    # pi is embedded as a numeric leaf (per grammar relaxation)
+    assert C.tree_size(tree_pi) == 1
+
+
+def test_numeric_literals_non_strict():
+    # The grammar relaxation: arbitrary constants ride as leaves.
+    tree = C.compile_expr("2 * x")
+    assert abs(C.eval_eml(tree, x=3.5) - 7.0) < 1e-9
+
+    tree = C.compile_expr("0.125")
+    assert abs(C.eval_eml(tree) - 0.125) < 1e-12
+
+
+def test_bare_eml_syntax():
+    """The parser accepts ``eml(a, b)`` directly — this is what EMLTree1D.to_expr emits."""
+    tree = C.compile_expr("eml(x, 1)")
+    # eml(x, 1) = exp(x) - ln(1) = exp(x) - 0 = exp(x)
+    v = C.eval_eml(tree, x=2.0)
+    assert abs(v.real - math.exp(2.0)) < 1e-10
+    # should be a single eml node with leaves x, 1 (no bootstrap overhead)
+    assert C.tree_size(tree) == 3
+    assert C.tree_depth(tree) == 1
+
+
+def test_nested_eml_syntax():
+    # ln(x) = eml(1, eml(eml(1, x), 1)) per §3
+    tree = C.compile_expr("eml(1, eml(eml(1, x), 1))")
+    v = C.eval_eml(tree, x=2.0)
+    assert abs(v.real - math.log(2.0)) < 1e-10
+
+
+# ─── Round-trip: to_string → parse → compile → evaluate ────────────
+
+ROUND_TRIP_EXPRS = [
+    "exp(x)",
+    "ln(x)",
+    "-x",
+    "x + y",
+    "x * y",
+    "x - y",
+    "x / y",
+    "x ^ y",
+    "sqrt(x + 1)",
+    "ln(x) + exp(y)",
+    "(x + y) * z",
+    "exp(-x) + 1",
+    "pi * x",
+]
+
+
+@pytest.mark.parametrize("expr", ROUND_TRIP_EXPRS)
+def test_round_trip_self(expr):
+    """to_string → parse → compile → same value as the original compiled tree."""
+    b = {"x": 1.5, "y": 2.5, "z": 3.5}
+    t1 = C.compile_expr(expr)
+    t2 = C.compile_expr(C.to_string(t1))
+    v1 = C.eval_eml(t1, b)
+    v2 = C.eval_eml(t2, b)
+    assert abs(v1 - v2) < 1e-10, f"{expr}: v1={v1} v2={v2}"
+
+
+# ─── Round-trip against a reference python eval ────────────────────
+
+def _reference_eval(expr: str, bindings: dict) -> complex:
+    """Use python's eval() with math symbols as the gold reference."""
+    env = {
+        "exp": np.exp, "log": np.log, "ln": np.log, "sqrt": np.sqrt,
+        "pi": math.pi, "e": math.e, "__builtins__": {},
+    }
+    env.update(bindings)
+    # JS-style ^ for power → python **
+    py_expr = expr.replace("^", "**")
+    return complex(eval(py_expr, env))  # noqa: S307 — controlled env
+
+
+@pytest.mark.parametrize(
+    "expr, bindings",
+    [
+        ("exp(x) + ln(y)",         {"x": 0.5, "y": 3.0}),
+        ("sqrt(x*x + y*y)",        {"x": 3.0, "y": 4.0}),
+        ("(x + 1) / (x - 1)",      {"x": 2.5}),
+        ("x^3 - 2*x + 1",          {"x": 1.5}),
+        ("ln(exp(x))",             {"x": 2.3}),
+        ("exp(ln(x))",             {"x": 7.1}),
+        ("e^x",                    {"x": 1.5}),
+    ],
+)
+def test_compile_matches_reference(expr, bindings):
+    tree = C.compile_expr(expr)
+    got = C.eval_eml(tree, bindings)
+    want = _reference_eval(expr, bindings)
+    # Generous tolerance — the bootstrap chain accumulates some rounding
+    # through repeated exp/ln and through IEEE-inf cancellation in add/neg.
+    assert abs(got - want) < 1e-6, f"{expr}: got {got}, want {want}, diff {got - want}"
+
+
+# ─── Strict mode ───────────────────────────────────────────────────
+
+STRICT_ACCEPTED = ["x", "x + x", "x * x", "exp(x)", "ln(x)", "e", "-x", "x^x", "1", "0"]
+
+
+@pytest.mark.parametrize("expr", STRICT_ACCEPTED)
+def test_strict_accepts(expr):
+    tree = C.compile_expr(expr, strict=True)
+    # All numeric leaves must be 0 or 1 in strict mode
+    for leaf in _walk_leaves(tree):
+        if not leaf.is_symbolic:
+            assert leaf.label in ("0", "1"), f"{expr}: forbidden leaf {leaf.label!r}"
+
+
+@pytest.mark.parametrize(
+    "expr, substring_in_error",
+    [
+        ("2",          "numeric literal"),
+        ("0.5",        "numeric literal"),
+        ("pi",         "π"),
+        ("3 * x",      "numeric literal"),
+    ],
+)
+def test_strict_rejects(expr, substring_in_error):
+    with pytest.raises(ValueError, match=substring_in_error):
+        C.compile_expr(expr, strict=True)
+
+
+def test_strict_neg_uses_eml_ln_one_not_literal_zero():
+    """Paper-faithful strict mode routes negation through eml_ln(1) instead
+    of a literal 0 leaf. Verify no '0' leaves appear."""
+    tree = C.compile_expr("-x", strict=True)
+    for leaf in _walk_leaves(tree):
+        assert leaf.label != "0", "strict -x should not contain a literal 0 leaf"
+    # Still evaluates correctly
+    assert abs(C.eval_eml(tree, x=2.0) - (-2.0)) < 1e-10
+
+
+def test_strict_sqrt_rewrites_half_as_one_over_two():
+    """sqrt in strict mode must not introduce a 0.5 leaf — it rewrites as
+    x^(1/(1+1))."""
+    tree = C.compile_expr("sqrt(x)", strict=True)
+    for leaf in _walk_leaves(tree):
+        if not leaf.is_symbolic:
+            assert leaf.label in ("0", "1"), f"strict sqrt leaked leaf {leaf.label!r}"
+    val = C.eval_eml(tree, x=16.0).real
+    assert abs(val - 4.0) < 1e-8
+
+
+def test_trig_rejected():
+    for fn in ("sin", "cos", "tan"):
+        with pytest.raises(ValueError, match="out of scope"):
+            C.compile_expr(f"{fn}(x)")
+
+
+# ─── Variables whitelist ───────────────────────────────────────────
+
+def test_variables_whitelist_accepts_listed():
+    tree = C.compile_expr("a + b", variables=["a", "b"])
+    assert abs(C.eval_eml(tree, a=2.0, b=3.0) - 5.0) < 1e-9
+
+
+def test_variables_whitelist_rejects_unlisted():
+    with pytest.raises(ValueError, match="unknown identifier 'z'"):
+        C.compile_expr("a + z", variables=["a", "b"])
+
+
+# ─── Tree utilities ────────────────────────────────────────────────
+
+def test_tree_size_and_depth_leaf():
+    leaf = Leaf(value=1.0, label="1")
+    assert C.tree_size(leaf) == 1
+    assert C.tree_depth(leaf) == 0
+
+
+def test_free_variables():
+    tree = C.compile_expr("x * y + z")
+    assert C.free_variables(tree) == {"x", "y", "z"}
+
+
+def test_missing_binding_raises():
+    tree = C.compile_expr("x + 1")
+    with pytest.raises(ValueError, match="no binding for variable 'x'"):
+        C.eval_eml(tree)
+
+
+# ─── EMLTree1D round-trip: compile(to_expr(tree)) ≈ tree(x) ────────
+
+@pytest.mark.parametrize("seed", list(range(5)))
+def test_round_trip_through_emltree1d(seed):
+    """For a snapped EMLTree1D, compile(tree.to_expr()) should evaluate
+    to the same number as the tree itself at a test point. This is the
+    compatibility contract mentioned in the issue.
+
+    The tree must be *snapped* first — ``to_expr`` reads argmax over
+    leaf/gate logits, but unsnapped ``forward`` returns the softmax
+    mixture. Snapping aligns them.
+    """
+    import eml_sr
+
+    torch.manual_seed(seed)
+    tree = eml_sr.EMLTree1D(depth=2).snap()
+    expr = tree.to_expr()
+
+    compiled = C.compile_expr(expr)
+    x_test = 1.5
+    y_compiled = C.eval_eml(compiled, x=x_test).real
+
+    with torch.no_grad():
+        y_tree, _, _ = tree(torch.tensor([[x_test]], dtype=torch.complex128))
+    y_tree = y_tree.real.item()
+
+    # Accept inf/nan matches; otherwise require tight numerical agreement.
+    if math.isnan(y_tree) or math.isnan(y_compiled):
+        assert math.isnan(y_tree) and math.isnan(y_compiled), (
+            f"seed={seed}: one is nan, other isn't — expr={expr!r}"
+        )
+        return
+    if math.isinf(y_tree) or math.isinf(y_compiled):
+        assert math.isinf(y_tree) and math.isinf(y_compiled), (
+            f"seed={seed}: one is inf, other isn't — expr={expr!r}"
+        )
+        assert (y_tree > 0) == (y_compiled > 0), (
+            f"seed={seed}: inf sign mismatch — expr={expr!r}"
+        )
+        return
+    assert abs(y_tree - y_compiled) < 1e-3, (
+        f"seed={seed} expr={expr!r}: tree={y_tree} compiled={y_compiled}"
+    )
+
+
+# ─── CLI ───────────────────────────────────────────────────────────
+
+def test_cli_prints_tree_size_depth():
+    result = subprocess.run(
+        [sys.executable, "-m", "eml_compiler", "ln(x) + exp(y)"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "eml(" in out
+    assert "size:" in out
+    assert "depth:" in out
+
+
+def test_cli_eval_flag():
+    result = subprocess.run(
+        [sys.executable, "-m", "eml_compiler", "x + y", "--eval", "x=2", "y=3"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "value:" in result.stdout
+    # 2 + 3 = 5; value line should contain "5"
+    assert "5" in result.stdout.split("value:", 1)[1]
+
+
+def test_cli_strict_rejects_literal():
+    result = subprocess.run(
+        [sys.executable, "-m", "eml_compiler", "--strict", "2 * x"],
+        capture_output=True, text=True, cwd=REPO_ROOT,
+    )
+    assert result.returncode == 2
+    assert "compile error" in result.stderr
+
+
+# ─── Helpers ───────────────────────────────────────────────────────
+
+def _walk_leaves(tree):
+    if isinstance(tree, Leaf):
+        yield tree
+        return
+    yield from _walk_leaves(tree.left)
+    yield from _walk_leaves(tree.right)


### PR DESCRIPTION
Implements #30 — port the JS reference compiler from [`eml-calc.html`](https://austegard.com/fun-and-games/eml-calc.html) to Python as a first-class module.

## What's added

- `eml_compiler.py` — `parse`, `compile`, `compile_expr`, `eval_eml`, `tree_size`, `tree_depth`, `to_string`, `to_string_pretty`, `free_variables`, plus CLI.
- `tests/test_eml_compiler.py` — 65 tests, ~6s to run.
- `README.md` — "Compiler" section + Files-table entry.
- `CLAUDE.md` — architecture-table entry for the new module.

## Primitive chain

Mirrors the JS reference exactly — same identities, same sizes:

| Primitive | Identity | Tree size |
|-----------|----------|-----------|
| `exp(x)` | `eml(x, 1)` | 3 |
| `ln(x)` | `eml(1, eml(eml(1, x), 1))` | 7 |
| `a - b` | `eml(ln(a), exp(b))` | 11 |
| `-x` | `sub(0, x)` | 11 |
| `a + b` | `sub(a, neg(b))` | 21 |
| `a * b` | `exp(ln(a) + ln(b))` | 35 |
| `a / b` | `a * inv(b)` | 53 |
| `a ^ b` | `exp(b * ln(a))` | 43 |

## Grammar relaxation — default vs strict

Default: `S → c | x | eml(S, S)`. Numeric constants and `π` ride as leaves, matching the JS compiler. Pragmatic for real-world data and for round-tripping `EMLTree1D.to_expr()` output (which may contain snapped floats).

`strict=True` (paper-faithful, `S → 1 | x | eml(S, S)`):
- Rejects numeric literals other than `0`, `1`.
- Rejects named constants other than `e` (= `eml(1, 1)`).
- Routes negation through `eml_ln(1)` instead of a literal `0` leaf, so every numeric leaf in the compiled tree is `1`.
- Rewrites `sqrt` as `x^(1/(1+1))` instead of `x^0.5`.

## Why numpy, not cmath

`cmath.log(0)` raises `ValueError`, but `eml_neg(x) = eml(ln(0), exp(x))` depends on `ln(0) = −∞` per CLAUDE.md invariant #6. Evaluator uses `numpy.log` / `numpy.exp` on `complex128`, which returns `−inf + 0j` and behaves correctly downstream. A `RuntimeWarning` is suppressed locally — this is the intended IEEE path, not a bug.

## Trig

Rejected at compile time with an explanatory error. §4.1: trig EML trees are enormous; use `exp`/`ln` with complex arguments if a transcendental path is actually needed.

## Tests

- **Primitives**: canonical tree-size + numerical-equivalence checks for all 10 operators.
- **Self round-trip**: `compile → to_string → parse → compile` preserves value, across 13 formulas.
- **Reference round-trip**: 7 formulas compared against `eval()` with `{np.exp, np.log, np.sqrt, ...}`, within `1e-6`.
- **Strict mode**: accept/reject matrix; paper-faithful leaf invariant checked for `-x` and `sqrt` in strict.
- **`EMLTree1D.to_expr` round-trip**: for 5 random seeds, `compile(snapped.to_expr())` evaluates to the same number as `snapped.forward(x)` at a test point.
- **CLI**: tree/size/depth output, `--eval`, `--strict` rejection.
- **Variables whitelist**: `variables=["a","b"]` rejects unlisted idents.
- **Missing binding** raises `ValueError` with the variable name.

All 65 pass in ~6s. Spot-checked `test_normalizer_multivariate.py` + `test_api_2d.py` — no regressions (expected: I only added new files).

## CLI

```
$ python -m eml_compiler "ln(x) + exp(y)" --eval x=2 y=1.5
eml(eml(1, eml(eml(1, eml(1, eml(eml(1, x), 1))), 1)), eml(y, 1))
size:  29
depth: 7
value: (5.1746...+0j)
```

The issue's originally-proposed `python -m eml_sr.compile` path would require repackaging `eml_sr.py` as a package, which is a separate refactor — `python -m eml_compiler` is the direct equivalent.

## Follow-ups enabled

- #32 (compiler-backed test suite): ground-truth trees from formulas.
- #33 (PySR head-to-head): needs reference tree size per target formula.
- Warm-start seeds for `discover_curriculum`.

## Duplicate housekeeping

#31 is a verbatim duplicate of #30 (I filed both two minutes apart in the 2026-04-18 roadmap burst). Closing it as duplicate after this merges.