### PR TITLE
Issue #32: compiler-backed test suite + GrammarError

### DIFF
--- a/eml_compiler.py
+++ b/eml_compiler.py
@@ -56,6 +56,19 @@ from typing import Iterable, Optional, Union
 
 import numpy as np
 
+# ─── Errors ────────────────────────────────────────────────────────
+
+class GrammarError(ValueError):
+    """Raised when ``strict=True`` rejects an input that isn't derivable
+    from the paper's pure grammar ``S -> 1 | x | eml(S, S)``.
+
+    Subclasses :class:`ValueError` for backward compatibility — existing
+    callers that catch ``ValueError`` still work; new callers can narrow
+    to ``GrammarError`` to distinguish strict-mode grammar violations
+    from parser/lexer errors.
+    """
+
+
 # ─── Tree representation ───────────────────────────────────────────
 
 @dataclass
@@ -354,8 +367,12 @@ def compile(ast: dict, *, strict: bool = False,
 
     Raises
     ------
+    GrammarError
+        In ``strict=True`` mode, when the input contains numeric literals
+        other than ``0`` / ``1`` or named constants other than ``e``.
+        Subclasses :class:`ValueError` for backward compatibility.
     ValueError
-        On unsupported operators (trig) or strict-mode violations.
+        On unsupported operators (trig) or other parser errors.
     """
     allowed_vars = set(variables) if variables is not None else None
 
@@ -365,7 +382,7 @@ def compile(ast: dict, *, strict: bool = False,
         if kind == "num":
             v = node["v"]
             if strict and v not in (0, 1):
-                raise ValueError(
+                raise GrammarError(
                     f"strict mode: numeric literal {v!r} is not derivable from "
                     "{{1, x}}; rewrite it algebraically (e.g. 2 -> 1+1) or use strict=False"
                 )
@@ -378,7 +395,7 @@ def compile(ast: dict, *, strict: bool = False,
                 return _E(_one(), _one(), "e")
             if name in ("pi", "π", "PI", "Pi"):
                 if strict:
-                    raise ValueError(
+                    raise GrammarError(
                         "strict mode: π requires a huge bootstrap tree "
                         "(π = -i·ln(-1)); use strict=False"
                     )

--- a/tests/test_compiler_grammar.py
+++ b/tests/test_compiler_grammar.py
@@ -1,0 +1,143 @@
+"""Strict-grammar regression lockdown (issue #32, deliverable D).
+
+The ``strict=True`` path in ``eml_compiler.compile()`` enforces the
+paper's pure grammar ``S -> 1 | x | eml(S, S)`` — no π, no arbitrary
+numeric literals. This file locks that behavior in so it can't
+silently drift when the compiler is refactored.
+
+Complementary to ``tests/test_eml_compiler.py::test_strict_accepts``
+and ``::test_strict_rejects``, which already parametrize a broader
+list. This file adds:
+
+1. ``GrammarError`` type contract — strict-mode violations must raise
+   a ``GrammarError`` specifically (not a bare ``ValueError``), so
+   callers can distinguish grammar violations from parser errors.
+2. Multivariate strict-accept — ``exp(x) - ln(y)`` is a two-variable
+   formula whose compiled tree contains only ``{0, 1}`` numeric
+   leaves and variable bindings. Ensures the strict checker doesn't
+   over-restrict on multivariate inputs.
+3. The exact cases named in the issue body: ``1.5`` rejected,
+   ``π * x`` rejected, ``exp(x) - ln(y)`` accepted.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import eml_compiler as C
+from eml_compiler import GrammarError
+
+
+# ─── GrammarError type contract ────────────────────────────────────
+
+
+def test_grammar_error_subclasses_value_error():
+    """``GrammarError`` subclasses ``ValueError`` for backward compat.
+
+    Existing callers that catch ``ValueError`` must continue to work;
+    new callers can narrow to ``GrammarError`` for strict-mode
+    violations specifically.
+    """
+    assert issubclass(GrammarError, ValueError)
+
+
+def test_strict_rejects_raise_grammar_error_specifically():
+    """The strict-mode rejections listed in the issue raise ``GrammarError``.
+
+    Parser errors (bad syntax, unknown operators) remain plain
+    ``ValueError`` — only grammar violations in strict mode are
+    ``GrammarError``. Callers that want to distinguish "this input was
+    rejected by the grammar" from "this input didn't parse" can narrow.
+    """
+    # Numeric literal outside {0, 1}
+    with pytest.raises(GrammarError, match="numeric literal"):
+        C.compile_expr("1.5", strict=True)
+
+    # π is the named-constant rejection path
+    with pytest.raises(GrammarError, match="π"):
+        C.compile_expr("pi", strict=True)
+
+    # Multiplicative form with π — same rejection, exercises the
+    # recursive path into strict=True from _eml_mul.
+    with pytest.raises(GrammarError, match="π"):
+        C.compile_expr("pi * x", strict=True)
+
+
+# ─── Cases named directly in the issue spec ────────────────────────
+
+
+def test_strict_accepts_exp_x():
+    """``compile("exp(x)", strict=True)`` — succeeds (issue §D example)."""
+    tree = C.compile_expr("exp(x)", strict=True)
+    # exp(x) = eml(x, 1) — all leaves are symbolic or ∈ {0, 1}
+    _assert_strict_leaves_only(tree)
+
+
+def test_strict_accepts_multivariate_exp_minus_ln():
+    """``compile("exp(x) - ln(y)", strict=True)`` — succeeds.
+
+    This is the canonical paper-faithful two-variable EML atom
+    (eml(x, y) itself expanded via the subtraction bootstrap). The
+    strict checker must not reject it just because it involves
+    multiple variables.
+    """
+    tree = C.compile_expr("exp(x) - ln(y)", strict=True)
+    _assert_strict_leaves_only(tree)
+
+
+def test_strict_rejects_bare_float():
+    """``compile("1.5", strict=True)`` — raises ``GrammarError``."""
+    with pytest.raises(GrammarError):
+        C.compile_expr("1.5", strict=True)
+
+
+def test_strict_rejects_pi_times_x():
+    """``compile("π * x", strict=True)`` — raises ``GrammarError``.
+
+    Uses the Unicode π identifier to exercise the same path used in
+    the paper's notation.
+    """
+    with pytest.raises(GrammarError):
+        C.compile_expr("π * x", strict=True)
+
+
+# ─── Non-strict still accepts what strict rejects ──────────────────
+
+
+def test_nonstrict_accepts_what_strict_rejects():
+    """Sanity: the grammar relaxation really does relax.
+
+    In non-strict mode (the default), ``1.5`` and ``π * x`` compile
+    without error — confirming that the strict rejections are a
+    deliberate paper-faithfulness check, not a parser limitation.
+    """
+    C.compile_expr("1.5")  # must not raise
+    C.compile_expr("pi * x")  # must not raise
+
+
+# ─── Helpers ───────────────────────────────────────────────────────
+
+
+def _walk_leaves(tree):
+    """Yield every Leaf in the tree (pre-order)."""
+    from eml_compiler import Leaf, Node
+    if isinstance(tree, Leaf):
+        yield tree
+        return
+    assert isinstance(tree, Node)
+    yield from _walk_leaves(tree.left)
+    yield from _walk_leaves(tree.right)
+
+
+def _assert_strict_leaves_only(tree):
+    """Every numeric leaf in the tree must be ``0`` or ``1``.
+
+    Symbolic leaves (variable references with ``value is None``) are
+    fine — they're not numeric literals.
+    """
+    for leaf in _walk_leaves(tree):
+        if leaf.is_symbolic:
+            continue
+        assert leaf.label in ("0", "1"), (
+            f"strict mode leaked a non-paper-faithful leaf: {leaf.label!r}"
+        )

--- a/tests/test_compiler_recovery.py
+++ b/tests/test_compiler_recovery.py
@@ -1,0 +1,203 @@
+"""Compiler-backed recovery tests (issue #32).
+
+The existing recovery tests in ``tests/test_eml_sr.py`` and
+``tests/test_e2e_multivariate.py`` hand-craft target ``y`` arrays with
+``np.exp(x)``, ``np.log(x)``, etc., then check that ``discover()``
+names the same formula. That pattern assumes the test author and the
+searcher agree on what e.g. ``exp(x)`` means numerically — a fair
+assumption, but it doesn't exercise the principled claim that the
+paper makes:
+
+    for any formula expressible as an EML tree, the searcher should
+    find a tree of comparable (or smaller) size, within machine
+    epsilon RMSE.
+
+Now that ``eml_compiler.compile_expr()`` exists (issue #30/#31), we
+have ground-truth EML trees for arbitrary elementary expressions. This
+module uses those trees to generate target values — so the test spec
+IS the formula string — and compares the discovered tree to the
+reference tree by size.
+
+Design notes
+------------
+- ``discover()`` returns ``result["depth"]``, the shallowest exact
+  depth on the ladder. We compare that against ``tree_depth()`` of
+  the reference tree from the compiler. The searcher should never
+  return a *deeper* tree than the compiler's bootstrap, because
+  ``discover()`` walks the ladder bottom-up and returns at the first
+  exact fit. (An earlier draft of this file tried to compare node
+  counts via ``tree_size()`` round-trip, but the compiler's ``sub``
+  bootstrap expands ``exp(x) - ln(y)`` into a 19-node tree while the
+  atom ``eml(x, y)`` is 3 nodes — same function, different
+  representations, incomparable node counts. Depth is the principled
+  metric.)
+- We gate on ``result.get("exact", True)`` — ``discover()`` omits the
+  ``"exact"`` key when it hits the success threshold, and sets it to
+  ``False`` otherwise.
+- Settings (``max_depth``, ``n_tries``) are tuned per formula depth to
+  keep wall-clock in CI reasonable. The paper-recovery sweep belongs
+  in issue #33 (PySR benchmark).
+- Non-goal: trig. The compiler refuses ``sin``/``cos``/``tan`` per
+  paper §4.1.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from eml_compiler import compile_expr, eval_eml, tree_depth
+from eml_sr import discover
+
+
+# ─── Helpers ───────────────────────────────────────────────────────
+
+
+def _eval_univariate(expr: str, x: np.ndarray) -> np.ndarray:
+    """Compile ``expr`` and evaluate it at each ``x[i]`` — returns real array."""
+    tree = compile_expr(expr)
+    ys = np.empty_like(x, dtype=float)
+    for i, xi in enumerate(x):
+        v = eval_eml(tree, x=float(xi))
+        ys[i] = v.real
+    return ys
+
+
+def _eval_multivariate(expr: str, X: np.ndarray, var_names: tuple) -> np.ndarray:
+    """Compile ``expr`` and evaluate at each row of ``X`` — returns real array."""
+    tree = compile_expr(expr, variables=var_names)
+    ys = np.empty(X.shape[0], dtype=float)
+    for i in range(X.shape[0]):
+        bindings = {name: float(X[i, j]) for j, name in enumerate(var_names)}
+        v = eval_eml(tree, bindings)
+        ys[i] = v.real
+    return ys
+
+
+# ─── Univariate recovery ───────────────────────────────────────────
+#
+# Catalog covers atoms (``x``, ``1``), depth-1 EML primitives
+# (``exp(x)``, ``e``), and a depth-1 subtract (``exp(x) - x``). Each
+# should recover exactly on the configured ladder. Deeper primitives
+# (``ln(x)`` → depth 3, ``1/x`` → depth 14 in the bootstrap) are
+# covered in ``tests/test_eml_sr.py`` and ``tests/test_eml_compiler.py``
+# under ``@pytest.mark.slow`` — no point duplicating them here.
+
+UNIVARIATE_CATALOG = [
+    # (formula, max_depth, n_tries) — settings scale with expected difficulty
+    ("x",            1, 2),
+    ("1",            1, 2),
+    ("exp(x)",       2, 4),
+    ("e",            1, 2),
+    ("exp(x) - x",   2, 4),
+]
+
+
+@pytest.mark.parametrize("formula, max_depth, n_tries", UNIVARIATE_CATALOG)
+def test_recovery_univariate(formula, max_depth, n_tries):
+    """Compiler-generated targets must be recovered exactly by the searcher.
+
+    Reference tree comes from ``compile_expr(formula)``; the target
+    array is ``eval_eml`` at each input point. ``discover()`` runs on
+    that target and must find an exact formula on the ladder. The
+    discovered depth must not exceed the reference depth (the searcher
+    should never need a deeper tree than the compiler's bootstrap to
+    represent an expression the compiler can build).
+    """
+    ref_tree = compile_expr(formula)
+    ref_depth = tree_depth(ref_tree)
+
+    x = np.linspace(0.5, 3.0, 40)
+    y = _eval_univariate(formula, x)
+
+    result = discover(x, y, max_depth=max_depth, n_tries=n_tries, verbose=False)
+    assert result is not None, f"discover() returned None on {formula!r}"
+    assert result.get("exact", True), (
+        f"{formula!r}: searcher did not hit success threshold "
+        f"(snap_rmse={result['snap_rmse']:.2e}, expr={result['expr']!r})"
+    )
+
+    assert result["depth"] <= ref_depth, (
+        f"{formula!r}: discovered depth {result['depth']} exceeds "
+        f"reference depth {ref_depth} (expr={result['expr']!r})"
+    )
+
+
+# ─── Multivariate catalog (deliverable B) ──────────────────────────
+#
+# Keep this conservative: the depth-1 EML atoms ``eml(x1, x2)``,
+# ``eml(x2, x1)``, and an identity ``eml(x1, 1) = exp(x1) - 0`` cover
+# the axes the searcher needs to exercise at n_vars=2. Deeper
+# multivariate targets (``x + y``, ``x * y`` — 21 and 35 nodes
+# respectively per ``test_primitive_sizes_and_values``) are out of
+# scope for a recovery test at the depths we can afford in CI; the
+# paper-rate sweep lives in issue #33.
+
+MULTIVARIATE_CATALOG = [
+    # (formula, n_vars, var_names, max_depth, n_tries)
+    ("eml(x1, x2)",       2, ("x1", "x2"), 1, 4),
+    ("eml(x2, x1)",       2, ("x1", "x2"), 1, 4),
+]
+
+
+@pytest.mark.parametrize(
+    "formula, n_vars, var_names, max_depth, n_tries", MULTIVARIATE_CATALOG
+)
+def test_recovery_multivariate(formula, n_vars, var_names, max_depth, n_tries):
+    """Multivariate compiler targets must be recovered exactly on the ladder.
+
+    The depth-1 ``eml(xi, xj)`` atoms are the smallest multivariate
+    trees expressible in the basis and should be found immediately.
+    """
+    ref_tree = compile_expr(formula, variables=var_names)
+    ref_depth = tree_depth(ref_tree)
+
+    rng = np.random.default_rng(0)
+    X = rng.uniform(0.5, 3.0, size=(40, n_vars))
+    y = _eval_multivariate(formula, X, var_names)
+
+    result = discover(X, y, max_depth=max_depth, n_tries=n_tries, verbose=False)
+    assert result is not None, f"discover() returned None on {formula!r}"
+    assert result["n_vars"] == n_vars, (
+        f"{formula!r}: expected n_vars={n_vars}, got {result['n_vars']}"
+    )
+    assert result.get("exact", True), (
+        f"{formula!r}: searcher did not hit success threshold "
+        f"(snap_rmse={result['snap_rmse']:.2e}, expr={result['expr']!r})"
+    )
+
+    assert result["depth"] <= ref_depth, (
+        f"{formula!r}: discovered depth {result['depth']} exceeds "
+        f"reference depth {ref_depth} (expr={result['expr']!r})"
+    )
+
+
+# ─── Harness sanity ────────────────────────────────────────────────
+
+
+def test_compiler_target_is_numerically_consistent():
+    """Compiler-generated targets for an identity formula equal the input.
+
+    A sanity check that the eval_eml bindings wiring is correct — if
+    this breaks, every recovery test above becomes meaningless.
+    """
+    x = np.linspace(0.5, 3.0, 20)
+    y_compiler = _eval_univariate("x", x)
+    np.testing.assert_allclose(y_compiler, x, atol=1e-12)
+
+
+def test_round_trip_discovered_expr_is_parseable():
+    """``discover()``'s ``expr`` output must round-trip through ``compile_expr``.
+
+    The searcher's simplifier can produce strings like ``"exp(x)"``,
+    ``"eml(x, 1)"``, or ``"(exp(x) - ln(y))"`` — all of which should
+    be parseable by the compiler. Breaking this contract would
+    invalidate any downstream tool that wants to re-compile discovered
+    expressions (e.g. size/depth analysis, simplification, export).
+    """
+    x = np.linspace(0.5, 3.0, 20)
+    y = x.copy()
+    result = discover(x, y, max_depth=1, n_tries=2, verbose=False)
+    assert result is not None
+    # Must not raise:
+    compile_expr(result["expr"])


### PR DESCRIPTION
Closes #32.

## Scope

Deliverables A, B, D per the issue body. **Deliverable C (retrofit `test_eml_sr.py`) deferred** — the existing hand-crafted targets there are stable and the retrofit risk/value ratio didn't justify piggybacking onto this PR. Suggest a follow-up issue if desired.

## Changes

### `eml_compiler.py`: new `GrammarError` class
Subclasses `ValueError` for backward compat. Retargets the two strict-mode raise sites (numeric-literal and π rejections). Updates the `Raises` docstring. Any existing caller that does `except ValueError` still catches these; new callers can narrow to `GrammarError`.

### `tests/test_compiler_recovery.py` (A + B)
Parametrized recovery tests driven by `compile_expr(formula)`:
- **Univariate catalog:** `x`, `1`, `exp(x)`, `e`, `exp(x) - x`
- **Multivariate catalog:** `eml(x1, x2)`, `eml(x2, x1)` at `n_vars=2`
- **Harness sanity:** compiler target equals input for identity; discovered expression round-trips through the compiler.

### `tests/test_compiler_grammar.py` (D)
Locks the `GrammarError` contract and the specific strict-mode cases named in the issue:
- Accepts: `exp(x)`, `exp(x) - ln(y)` (the multivariate case not already covered in `test_eml_compiler.py`)
- Rejects: `1.5`, `pi`, `pi * x` — each raises `GrammarError` specifically (not a bare `ValueError`)
- Non-strict still accepts what strict rejects — sanity that the grammar relaxation is a real relaxation.

Complements (doesn't duplicate) the parametrized `test_strict_accepts` / `test_strict_rejects` already in `test_eml_compiler.py`.

## Pivot from the spec: depth, not size

The issue sketch asserted `result["tree_size"] <= ref_size * 1.5`. Two problems found during implementation:

1. `discover()` has no `tree_size` key — actual returned fields are `expr`, `depth`, `snap_rmse`, `snapped_tree`, `n_uncertain`, `n_vars`, optional `exact`.
2. Round-tripping the discovered expression back through `compile_expr` for a comparable node count is ambiguous. The atom `eml(x1, x2)` is 3 nodes; its mathematically equivalent expansion `exp(x1) - ln(y)` is **19 nodes** after the `sub`/`ln`/`exp` bootstrap expands out. Same function, incomparable node counts.

**Switched to depth comparison:** `result["depth"] <= tree_depth(ref_tree)`. This is a real regression gate because `discover()` walks the ladder bottom-up and returns the shallowest exact solution — if the searcher ever needs more ladder than the compiler's bootstrap, something regressed.

Flagging in case you'd rather I'd added a `tree_size` field to `discover()`'s return dict and matched the literal spec. The depth-based version is simpler and (I argue) more principled, but it IS a reinterpretation.

## Other sketch-vs-reality mismatches silently corrected
- `compile()` takes an AST dict, not a string → used `compile_expr(str)` throughout.
- `eval_eml_at(...)` doesn't exist → used `eval_eml(tree, bindings=dict)`.
- `result["rmse"]` → `result["snap_rmse"]`.
- Exact-recovery gate uses `result.get("exact", True)` — `discover()` omits the `exact` key when it succeeds, sets it to `False` otherwise.

## Test results

```
tests/test_compiler_grammar.py      7 passed in 0.3s
tests/test_compiler_recovery.py     9 passed in ~2.5m
tests/test_eml_compiler.py         65 passed  (no regressions from GrammarError)
```

## Paper references
- §4.1 — the pure grammar `S -> 1 | x | eml(S, S)` that strict mode enforces.
- §4.3 — recovery-rate claims; recovery sweeps proper belong in #33.

## Non-goals
- Not a benchmark. No timing claims, no recovery-rate sweep.
- No trig. Compiler refuses sin/cos/tan; tests do the same.