### PR TITLE
Retrofit hand-crafted targets in test_eml_sr.py to compile_expr() (closes #40)

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,35 @@
+"""Shared test helpers.
+
+Compiler-backed evaluation utilities: turn a formula string into a
+real-valued target array by compiling to an EML tree and evaluating it
+point-by-point. Using these in place of hand-crafted ``np.exp`` /
+``np.log`` targets makes the formula string the spec and catches drift
+between the compiler's eval semantics and the searcher's simplifier.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from eml_compiler import compile_expr, eval_eml
+
+
+def eval_formula_univariate(formula: str, x: np.ndarray) -> np.ndarray:
+    """Compile ``formula`` and evaluate it at each ``x[i]`` — returns real array."""
+    tree = compile_expr(formula)
+    ys = np.empty_like(x, dtype=float)
+    for i, xi in enumerate(x):
+        v = eval_eml(tree, x=float(xi))
+        ys[i] = v.real
+    return ys
+
+
+def eval_formula_multivariate(formula: str, X: np.ndarray,
+                              var_names: tuple) -> np.ndarray:
+    """Compile ``formula`` and evaluate at each row of ``X`` — returns real array."""
+    tree = compile_expr(formula, variables=var_names)
+    ys = np.empty(X.shape[0], dtype=float)
+    for i in range(X.shape[0]):
+        bindings = {name: float(X[i, j]) for j, name in enumerate(var_names)}
+        v = eval_eml(tree, bindings)
+        ys[i] = v.real
+    return ys

--- a/tests/test_compiler_recovery.py
+++ b/tests/test_compiler_recovery.py
@@ -46,32 +46,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from eml_compiler import compile_expr, eval_eml, tree_depth
+from eml_compiler import compile_expr, tree_depth
 from eml_sr import discover
 
-
-# ─── Helpers ───────────────────────────────────────────────────────
-
-
-def _eval_univariate(expr: str, x: np.ndarray) -> np.ndarray:
-    """Compile ``expr`` and evaluate it at each ``x[i]`` — returns real array."""
-    tree = compile_expr(expr)
-    ys = np.empty_like(x, dtype=float)
-    for i, xi in enumerate(x):
-        v = eval_eml(tree, x=float(xi))
-        ys[i] = v.real
-    return ys
-
-
-def _eval_multivariate(expr: str, X: np.ndarray, var_names: tuple) -> np.ndarray:
-    """Compile ``expr`` and evaluate at each row of ``X`` — returns real array."""
-    tree = compile_expr(expr, variables=var_names)
-    ys = np.empty(X.shape[0], dtype=float)
-    for i in range(X.shape[0]):
-        bindings = {name: float(X[i, j]) for j, name in enumerate(var_names)}
-        v = eval_eml(tree, bindings)
-        ys[i] = v.real
-    return ys
+from tests._helpers import eval_formula_multivariate, eval_formula_univariate
 
 
 # ─── Univariate recovery ───────────────────────────────────────────
@@ -108,7 +86,7 @@ def test_recovery_univariate(formula, max_depth, n_tries):
     ref_depth = tree_depth(ref_tree)
 
     x = np.linspace(0.5, 3.0, 40)
-    y = _eval_univariate(formula, x)
+    y = eval_formula_univariate(formula, x)
 
     result = discover(x, y, max_depth=max_depth, n_tries=n_tries, verbose=False)
     assert result is not None, f"discover() returned None on {formula!r}"
@@ -154,7 +132,7 @@ def test_recovery_multivariate(formula, n_vars, var_names, max_depth, n_tries):
 
     rng = np.random.default_rng(0)
     X = rng.uniform(0.5, 3.0, size=(40, n_vars))
-    y = _eval_multivariate(formula, X, var_names)
+    y = eval_formula_multivariate(formula, X, var_names)
 
     result = discover(X, y, max_depth=max_depth, n_tries=n_tries, verbose=False)
     assert result is not None, f"discover() returned None on {formula!r}"
@@ -182,7 +160,7 @@ def test_compiler_target_is_numerically_consistent():
     this breaks, every recovery test above becomes meaningless.
     """
     x = np.linspace(0.5, 3.0, 20)
-    y_compiler = _eval_univariate("x", x)
+    y_compiler = eval_formula_univariate("x", x)
     np.testing.assert_allclose(y_compiler, x, atol=1e-12)
 
 

--- a/tests/test_eml_sr.py
+++ b/tests/test_eml_sr.py
@@ -36,6 +36,8 @@ from eml_sr import (
     reachable_exprs,
 )
 
+from tests._helpers import eval_formula_univariate
+
 
 # ───────────────────────── helpers ──────────────────────────
 
@@ -240,7 +242,7 @@ class TestRecovery:
     def test_recover_exp_depth1_fast(self):
         """exp(x) at depth 1 — should succeed on seed 0 alone."""
         x = np.linspace(0.5, 2.5, 20)
-        y = np.exp(x)
+        y = eval_formula_univariate("exp(x)", x)
         out = _fast_train(x, y, depth=1, seed=0, search=700, hard=250)
         assert out["snap_rmse"] < 1e-8
         assert out["expr"] == "exp(x)"
@@ -248,7 +250,7 @@ class TestRecovery:
     def test_recover_constant_e_depth1_fast(self):
         """Constant `e` is depth 1 — routing picks child = eml(1,1) = exp(1) - ln(1) = e."""
         x = np.linspace(0.5, 2.5, 20)
-        y = np.full_like(x, np.e)
+        y = eval_formula_univariate("e", x)
         out = _fast_train(x, y, depth=1, seed=0, search=700, hard=250)
         assert out["snap_rmse"] < 1e-8
         assert out["expr"] == "e"
@@ -262,7 +264,7 @@ class TestRecovery:
     def test_train_depth0_identity(self):
         """A depth-0 tree trained on y = x must snap to the leaf `x`."""
         x = np.linspace(0.5, 2.5, 20)
-        y = x.copy()
+        y = eval_formula_univariate("x", x)
         out = _fast_train(x, y, depth=0, seed=0, search=300, hard=100)
         assert out["snap_rmse"] < 1e-10
         assert out["expr"] == "x"
@@ -270,7 +272,7 @@ class TestRecovery:
     def test_train_depth0_constant_one(self):
         """A depth-0 tree trained on y = 1 must snap to the leaf `1`."""
         x = np.linspace(0.5, 2.5, 20)
-        y = np.ones_like(x)
+        y = eval_formula_univariate("1", x)
         out = _fast_train(x, y, depth=0, seed=0, search=300, hard=100)
         assert out["snap_rmse"] < 1e-10
         assert out["expr"] == "1"
@@ -278,7 +280,7 @@ class TestRecovery:
     def test_discover_identity_at_depth0(self):
         """`discover()` ladder must reach y = x at depth 0, not depth 4."""
         x = np.linspace(0.5, 3.0, 40)
-        y = x.copy()
+        y = eval_formula_univariate("x", x)
         r = discover(x, y, max_depth=2, n_tries=2, verbose=False,
                      success_threshold=1e-10)
         assert r is not None
@@ -289,7 +291,7 @@ class TestRecovery:
     def test_discover_curriculum_identity_at_depth0(self):
         """`discover_curriculum()` must hit the depth-0 pre-check for y = x."""
         x = np.linspace(0.5, 3.0, 40)
-        y = x.copy()
+        y = eval_formula_univariate("x", x)
         r = discover_curriculum(x, y, max_depth=3, n_tries=1, verbose=False,
                                 success_threshold=1e-10)
         assert r is not None
@@ -302,7 +304,7 @@ class TestRecovery:
     def test_discover_curriculum_constant_one_at_depth0(self):
         """Pre-check must also catch y = 1 without entering the growing loop."""
         x = np.linspace(0.5, 3.0, 40)
-        y = np.ones_like(x)
+        y = eval_formula_univariate("1", x)
         r = discover_curriculum(x, y, max_depth=3, n_tries=1, verbose=False,
                                 success_threshold=1e-10)
         assert r is not None
@@ -312,7 +314,7 @@ class TestRecovery:
     def test_depth0_does_not_hijack_nonatom(self):
         """y = exp(x) must not be mis-recovered at depth 0; the ladder must go deeper."""
         x = np.linspace(0.5, 2.5, 30)
-        y = np.exp(x)
+        y = eval_formula_univariate("exp(x)", x)
         r = discover(x, y, max_depth=2, n_tries=4, verbose=False,
                      success_threshold=1e-10)
         assert r is not None
@@ -323,7 +325,7 @@ class TestRecovery:
     def test_recover_exp_depth1_ladder(self):
         """≤4 seeds at depth 1 must recover exp(x)."""
         x = np.linspace(0.5, 2.5, 25)
-        y = np.exp(x)
+        y = eval_formula_univariate("exp(x)", x)
         r = discover(x, y, max_depth=1, n_tries=4, verbose=False)
         assert r is not None
         assert r["snap_rmse"] < 1e-8
@@ -333,7 +335,7 @@ class TestRecovery:
     def test_recover_constant_e(self):
         """Constant e at depth 1 — 100% success within a few seeds."""
         x = np.linspace(0.5, 2.5, 25)
-        y = np.full_like(x, np.e)
+        y = eval_formula_univariate("e", x)
         r = discover(x, y, max_depth=1, n_tries=4, verbose=False)
         assert r is not None
         assert r["snap_rmse"] < 1e-8
@@ -346,7 +348,7 @@ class TestRecovery:
         Requires 8 seeds for ≥75% aggregate success — we just need ≥1 hit.
         """
         x = np.linspace(0.5, 5.0, 30)
-        y = np.log(x)
+        y = eval_formula_univariate("ln(x)", x)
         r = discover(x, y, max_depth=3, n_tries=8, verbose=False)
         assert r is not None
         # ln is hard from random init; accept either exact or near-exact fit.
@@ -356,7 +358,7 @@ class TestRecovery:
     def test_recover_exp_minus_ln(self):
         """exp(x) - ln(x) = eml(x, x) at depth 1 — exercises the gate routing."""
         x = np.linspace(0.5, 3.0, 25)
-        y = np.exp(x) - np.log(x)
+        y = eval_formula_univariate("exp(x) - ln(x)", x)
         r = discover(x, y, max_depth=2, n_tries=8, verbose=False)
         assert r is not None
         # Accept any formula within tight RMSE — exact form may differ.


### PR DESCRIPTION
## Summary

- Replaces twelve `np.exp` / `np.log` / `x.copy()` / `np.ones_like` / `np.full_like` targets in `tests/test_eml_sr.py::TestRecovery` with `eval_formula_univariate(formula, x)`, which compiles the formula string via `eml_compiler.compile_expr` and evaluates it pointwise. The formula string is now the spec — any drift between the compiler's eval semantics, the searcher's simplifier, or the primitive identities fails loudly instead of silently agreeing via numpy.
- Promotes `_eval_univariate` / `_eval_multivariate` from `tests/test_compiler_recovery.py` into a shared `tests/_helpers.py` module and imports from both modules (one-line helper, no inline duplication).
- Assertion logic is unchanged in every retrofitted test (`assert r["depth"] == 0`, `assert r["expr"] == "x"`, etc.).

## Retrofitted tests (12)

All under `tests/test_eml_sr.py::TestRecovery`:

| Test | Retrofit |
|------|----------|
| `test_recover_exp_depth1_fast` | `compile_expr("exp(x)")` |
| `test_recover_constant_e_depth1_fast` | `compile_expr("e")` |
| `test_train_depth0_identity` | `compile_expr("x")` |
| `test_train_depth0_constant_one` | `compile_expr("1")` |
| `test_discover_identity_at_depth0` | `compile_expr("x")` |
| `test_discover_curriculum_identity_at_depth0` | `compile_expr("x")` |
| `test_discover_curriculum_constant_one_at_depth0` | `compile_expr("1")` |
| `test_depth0_does_not_hijack_nonatom` | `compile_expr("exp(x)")` |
| `test_recover_exp_depth1_ladder` | `compile_expr("exp(x)")` |
| `test_recover_constant_e` | `compile_expr("e")` |
| `test_recover_ln_depth3` | `compile_expr("ln(x)")` |
| `test_recover_exp_minus_ln` | `compile_expr("exp(x) - ln(x)")` |

(Issue body says "thirteen" but the mapping table has twelve rows — matched the table.)

## Out of scope

- `test_training_with_harsh_target_recovers_gracefully` (line 400, `y = np.sin(x)`) — the compiler refuses trig per paper §4.1, and that test intentionally probes behavior on targets the basis can't represent. Left alone per the issue.
- `tests/test_e2e_multivariate.py`'s `_bivariate_eml_target` — issue #40's scope lists only `test_eml_sr.py`; the multivariate helper can be retrofitted in a separate follow-up if desired. The new `tests/_helpers.py` already exposes `eval_formula_multivariate` so the follow-up is mechanical.

## Test plan

- [x] Full `pytest tests/test_eml_sr.py tests/test_compiler_recovery.py` green — 75 passed including slow-marked recovery tests.
- [x] Assertion logic unchanged (grep of `assert` lines in `TestRecovery` matches pre-retrofit).
- [x] Helper promoted: no duplicate `_eval_univariate` bodies remain across test modules.