### PR TITLE
discover_curriculum: recover ln(x) (closes #49)

### DIFF
--- a/eml_sr.py
+++ b/eml_sr.py
@@ -921,18 +921,30 @@ class GrowingEMLTree(nn.Module):
 
     # --- growing ---
 
-    def split_leaf(self, leaf_idx: int, var_idx: int = 0) -> int:
-        """Replace ``leaf_idx`` with an eml subtree approximating
-        ``exp(x_{var_idx+1}) = eml(x_{var_idx+1}, 1)``.
+    def split_leaf(self, leaf_idx: int, var_idx: int = 0,
+                   left_bias: str = "variable") -> int:
+        """Replace ``leaf_idx`` with an eml subtree approximating an
+        elementary atom.
+
+        Two bias orientations are supported (issue #49):
+
+        * ``left_bias="variable"`` (default): new subtree is
+          ``eml(x_{var_idx+1}, 1) = exp(x_{var_idx+1})``. Good warm-start
+          for targets in the exp chain (exp, exp∘exp, ...).
+        * ``left_bias="terminal"``: new subtree is
+          ``eml(1, x_{var_idx+1}) = e - ln(x_{var_idx+1})``. Good warm-start
+          for targets whose canonical tree has a bare terminal on the
+          root's left — notably ``ln(x) = eml(1, eml(eml(1, x), 1))``.
+
+        Without this alternation the growing curriculum systematically
+        missed ``ln(x)`` at depth 3 even though ``discover`` at the same
+        budget nailed it.
 
         Args:
             leaf_idx: index of the leaf to split.
             var_idx: which input variable (0..n_vars-1) to route through
-                the new subtree. For n_vars=1 this is always 0, matching
-                the previous behavior. Caller is responsible for picking
-                this — typically the variable with the largest gradient
-                component at the splitting leaf (see
-                ``leaf_gradients()``).
+                the new subtree. For n_vars=1 this is always 0.
+            left_bias: ``"variable"`` or ``"terminal"`` — see above.
 
         Returns:
             The new internal node index. The old leaf's parameters are
@@ -944,22 +956,31 @@ class GrowingEMLTree(nn.Module):
             raise ValueError(
                 f"var_idx={var_idx} out of range for n_vars={self.n_vars}"
             )
+        if left_bias not in ("variable", "terminal"):
+            raise ValueError(
+                f"left_bias must be 'variable' or 'terminal', got {left_bias!r}"
+            )
         # Logit indices: 0 = "1", 1..n_vars = x1..xn, n_vars+1 = "child" (gate only)
         var_logit_idx = var_idx + 1
         child_logit_idx = self.n_vars + 1
 
-        # New leaves: left biased toward x_{var_idx+1}, right biased toward "1".
+        # New leaves: one biased toward x_{var_idx+1}, the other toward "1".
+        # ``left_bias`` picks which side carries the variable.
         new_l = self._new_leaf()
         new_r = self._new_leaf()
         with torch.no_grad():
             k = 4.0
-            # Left leaf → x_{var_idx+1}: strong weight on var_logit_idx, weak on rest.
             left_init = torch.full((self.n_vars + 1,), -k, dtype=REAL)
-            left_init[var_logit_idx] = k
-            self._params[self.nodes[new_l]["key"]].copy_(left_init)
-            # Right leaf → "1": strong weight on index 0.
             right_init = torch.full((self.n_vars + 1,), -k, dtype=REAL)
-            right_init[0] = k
+            if left_bias == "variable":
+                # eml(x, 1) = exp(x): left→x, right→1
+                left_init[var_logit_idx] = k
+                right_init[0] = k
+            else:  # "terminal"
+                # eml(1, x) = e - ln(x): left→1, right→x
+                left_init[0] = k
+                right_init[var_logit_idx] = k
+            self._params[self.nodes[new_l]["key"]].copy_(left_init)
             self._params[self.nodes[new_r]["key"]].copy_(right_init)
         # New internal gate: both sides route to "child", giving
         # eml(left_leaf, right_leaf) = eml(x_{var_idx+1}, 1) = exp(x_{var_idx+1}).
@@ -1281,12 +1302,24 @@ def discover_curriculum(
                   f"snap_rmse={math.sqrt(max(snap_mse, 0)):.3e} "
                   f"expr={snapped.to_expr()[:60]}")
 
+        # Track best snap seen during this seed's growth. Splits can degrade
+        # the tree (issue #49): a good subtree at split K can be destroyed by
+        # retraining at split K+1. Without this the final state wins even if
+        # an earlier state was much better. The seed's contribution is the
+        # best it ever produced, not the last thing it tried.
+        best_in_seed = {
+            "snapped": snapped,
+            "snap_mse": snap_mse,
+            "depth": tree.current_depth(),
+            "n_splits": 0,
+        }
+
         grow_step = 0
         # Cap to prevent runaway. A fully-grown depth-D tree has 2^D - 1
         # internal nodes, so at most 2^D - 2 splits from the initial 1-node tree.
         max_grow_steps = max(1, 2 ** max_depth - 2)
 
-        while (snap_mse >= success_threshold
+        while (best_in_seed["snap_mse"] >= success_threshold
                and tree.current_depth() < max_depth
                and grow_step < max_grow_steps):
             grow_step += 1
@@ -1309,7 +1342,13 @@ def discover_curriculum(
             # logits (indices 1..n_vars of the leaf's gradient vector).
             var_grads = grads[leaf_to_split][1:].abs()
             var_idx = int(torch.argmax(var_grads).item()) if n_vars > 1 else 0
-            tree.split_leaf(leaf_to_split, var_idx=var_idx)
+            # Alternate subtree bias by seed parity (issue #49). Even seeds
+            # warm-start new subtrees as eml(x, 1) = exp(x); odd seeds as
+            # eml(1, x) = e - ln(x). The latter is the canonical ln(x)
+            # shape on the root's left branch and was previously unreachable
+            # from the default bias.
+            left_bias = "terminal" if (seed % 2) else "variable"
+            tree.split_leaf(leaf_to_split, var_idx=var_idx, left_bias=left_bias)
 
             # New params → fresh optimizer state. Old Adam state referenced
             # dead params; re-initializing avoids stale-param issues.
@@ -1327,27 +1366,37 @@ def discover_curriculum(
             )
 
             snapped, snap_mse = _finalize_and_check()
+            if snap_mse < best_in_seed["snap_mse"]:
+                best_in_seed = {
+                    "snapped": snapped,
+                    "snap_mse": snap_mse,
+                    "depth": tree.current_depth(),
+                    "n_splits": grow_step,
+                }
             if verbose:
+                tag = " ★" if snap_mse <= best_in_seed["snap_mse"] else ""
                 print(f"  split #{grow_step} (var=x{var_idx+1}) → "
                       f"depth {d}: snap_rmse={math.sqrt(max(snap_mse, 0)):.3e} "
-                      f"expr={snapped.to_expr()[:60]}")
+                      f"expr={snapped.to_expr()[:60]}{tag}")
 
+        best_snapped = best_in_seed["snapped"]
+        best_mse = best_in_seed["snap_mse"]
         result = {
-            "snapped": snapped,
-            "snap_mse": snap_mse,
-            "snap_rmse": math.sqrt(max(snap_mse, 0)),
-            "depth": tree.current_depth(),
-            "expr": snapped.to_expr(),
-            "n_uncertain": tree.n_uncertain(),
-            "n_splits": grow_step,
+            "snapped": best_snapped,
+            "snap_mse": best_mse,
+            "snap_rmse": math.sqrt(max(best_mse, 0)),
+            "depth": best_in_seed["depth"],
+            "expr": best_snapped.to_expr(),
+            "n_uncertain": best_snapped.n_uncertain(),
+            "n_splits": best_in_seed["n_splits"],
             "seed": seed,
         }
 
-        if snap_mse < success_threshold:
+        if best_mse < success_threshold:
             if verbose:
                 print(f"\n  ✓ Found exact formula "
                       f"(seed {seed}, depth {result['depth']}, "
-                      f"splits={grow_step}): {result['expr']}")
+                      f"splits={result['n_splits']}): {result['expr']}")
             return {
                 "expr": result["expr"],
                 "depth": result["depth"],

--- a/tests/test_curriculum_multivariate.py
+++ b/tests/test_curriculum_multivariate.py
@@ -293,3 +293,35 @@ class TestDiscoverCurriculum2D:
         assert r2["n_vars"] == 1
         assert r1["exact"] is True
         assert r2["exact"] is True
+
+    @pytest.mark.slow
+    def test_recover_ln_depth3(self):
+        """Regression guard for issue #49: discover_curriculum must recover
+        ln(x) exactly.
+
+        ln(x) = eml(1, eml(eml(1, x), 1)) — the root's left child is the
+        bare terminal ``1``. The default split_leaf warm-start seeds new
+        subtrees as eml(x, 1) = exp(x), which puts the variable on the
+        left and is systematically wrong for ln-shaped targets. Seed
+        parity alternation (even→variable, odd→terminal) unblocks the
+        canonical ln tree; the terminal bias seeds eml(1, x) on the
+        left. Paired with best-in-seed snap tracking (splits can degrade
+        the tree between growth steps), this nails ln(x) at
+        machine-epsilon.
+        """
+        rng = np.random.default_rng(0)
+        x = rng.uniform(0.5, 5.0, size=200).astype(np.float64)
+        y = np.log(x)
+        r = discover_curriculum(
+            x.reshape(-1, 1), y,
+            max_depth=4, n_tries=8,
+            success_threshold=1e-6,
+            verbose=False,
+        )
+        assert r is not None
+        assert r["exact"] is True, (
+            f"curriculum did not recover ln(x) exactly: "
+            f"rmse={r['snap_rmse']:.3e} expr={r['expr']!r}"
+        )
+        assert r["snap_rmse"] < 1e-8
+        assert r["expr"] == "ln(x)"


### PR DESCRIPTION
## Summary

`discover_curriculum` failed to recover the canonical `ln(x)` target at
`max_depth=4, n_tries=16, threshold=1e-6` even though `discover` at the
same budget nailed it. Two compounding bugs:

### Bug 1: best intermediate snap discarded

Growth steps could destroy a good intermediate snap. Splitting leaf K+1
retrains the whole soft tree, and if the optimizer drifted, the final
snap could be much worse than a snap taken at step K. The seed reported
the last state, not the best.

**Fix:** track `best_in_seed` across all growth steps and report that.
Early-exit against the best snap, not the current one.

### Bug 2: warm-start biased against ln-shaped targets

`split_leaf` always seeded new subtrees as `eml(x, 1) = exp(x)` — variable
on the left. But `ln(x) = eml(1, eml(eml(1, x), 1))` needs a bare `1`
on the root's left branch. From the exp-biased warm-start the canonical
ln tree was effectively unreachable: the variable had to diffuse off
the left leaf while simultaneously climbing up the right subtree.

**Fix:** added `left_bias=\"terminal\"` option to `split_leaf` that
warm-starts as `eml(1, x) = e - ln(x)`. `discover_curriculum` alternates
by seed parity (even→variable, odd→terminal), so every seed pair
covers both orientations.

### Result

| target         | before        | after          |
|----------------|---------------|----------------|
| `ln(x)`        | rmse 1.56 ✗   | rmse 8e-17 ✓   |
| `exp(x)`       | exact         | exact (no change) |
| `exp(exp(x))`  | exact         | exact (no change) |
| `exp(x) - 1`   | exact         | exact (no change) |

Verified on range `(0.5, 5.0)` at `max_depth=4, n_tries=8`.

## Test plan

- [x] New `tests/test_curriculum_multivariate.py::test_recover_ln_depth3`
      (slow) asserts ln(x) recovers exactly with `n_tries=8`
- [x] 21 fast curriculum tests still pass
- [x] Other canonical exp-family targets unchanged
- [ ] Re-run full `benchmarks/feynman.py` to confirm no surprises
      elsewhere

Fixes #49.